### PR TITLE
[netlify] Remove "base" from Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,9 +9,8 @@
 # and here https://answers.netlify.com/t/builds-cancelled-for-a-new-branch-due-to-no-content-change/17169/4
 ignore = "if [ \"$PULL_REQUEST\" == \"true\" ]; then git diff --quiet main $COMMIT_REF . ; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF; fi"
 
-base = "developer-docs-site/"
-
-# This is relative to base.
-publish = "build/"
-
+# Build command
 command = "pnpm build"
+
+# Build directory
+publish = "build"


### PR DESCRIPTION
### Description

Netlify deploy failed during initializing step. This is due to `netlify.toml` config needing to be updated as we should no longer need to define a base directory since we are now in the root of the repo. 

![image](https://github.com/aptos-labs/developer-docs/assets/98909677/4f747eca-8434-4a07-95aa-abf2c96616c7)



### Checklist

- [x] Do all Lints pass?
- [x] Have you ran `pnpm spellcheck`?
- [x] Have you ran `pnpm fmt`?
- [x] Have you ran `pnpm lint`?
