### PR TITLE
Fix Ecosystem references

### DIFF
--- a/docs/aptos-white-paper/index.md
+++ b/docs/aptos-white-paper/index.md
@@ -2,6 +2,10 @@
 title: "Aptos White Paper"
 ---
 
+<head>
+  <link rel="canonical" href="https://aptosfoundation.org/whitepaper" />
+</head>
+
 # The Aptos Blockchain
 ## A Safe, Scalable, and Upgradeable Web3 Infrastructure
 

--- a/docs/community/contributions/remix-ide-plugin.md
+++ b/docs/community/contributions/remix-ide-plugin.md
@@ -55,7 +55,7 @@ width="50%"
 
 ## Step 3: Install a wallet
 
-WELLDONE Wallet can be used with the Remix IDE plugin now, with support for [Petra wallet](https://petra.app/) coming soon. See the list of [Aptos wallets](https://github.com/aptos-foundation/ecosystem-projects#wallets) available in the ecosystem.
+WELLDONE Wallet can be used with the Remix IDE plugin now, with support for [Petra wallet](https://petra.app/) coming soon. See the list of [Aptos wallets](https://aptosfoundation.org/ecosystem/projects/wallets) available in the ecosystem.
 
 This steps assumes you are using the WELLDONE Wallet. Follow [the manual](https://docs.welldonestudio.io/wallet/manual/) to install the wallet and create an account for the Aptos blockchain. Once that is done, follow these steps:
 

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -5,7 +5,7 @@ slug: ./
 
 # Contribute to the Aptos Ecosystem
 
-We welcome your own [contributions](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) to the [Aptos](https://aptosfoundation.org/currents) blockchain and this site! Aptos exists to foster an inclusive ecosystem. This page describes ways you can help, while the other pages in this section highlight our community's contributions.
+We welcome your own [contributions](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) to the [Aptos](https://aptosfoundation.org) blockchain and this site! Aptos exists to foster an inclusive ecosystem. This page describes ways you can help, while the other pages in this section highlight our community's contributions.
 
 As always, adhere to the [Aptos Code of Conduct](https://github.com/aptos-labs/aptos-core/blob/main/CODE_OF_CONDUCT.md) when taking part in our ecosystem.
 
@@ -32,7 +32,7 @@ Here are the primary bug queues:
 
 ## Develop your own project
 
-See, employ and join the growing number of delightful [community-driven projects](https://github.com/aptos-foundation/ecosystem-projects) in the Aptos ecosystem.
+See, employ and join the growing number of delightful [community-driven projects](https://aptosfoundation.org/ecosystem/projects/all) in the Aptos ecosystem.
 
 ## Become an Aptos ambassador
 

--- a/docs/guides/explore-aptos.md
+++ b/docs/guides/explore-aptos.md
@@ -10,7 +10,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Use the Aptos Explorer
 
-The [Aptos Explorer](https://explorer.aptoslabs.com/) lets you delve into the activity on the Aptos blockchain in great detail, seeing transactions, validators, and account information. With the Aptos Explorer, you can ensure that the transactions performed on Aptos are accurately reflected. Note, the Aptos ecosystem has [several other explorers](https://github.com/aptos-foundation/ecosystem-projects#explorers) to choose from.
+The [Aptos Explorer](https://explorer.aptoslabs.com/) lets you delve into the activity on the Aptos blockchain in great detail, seeing transactions, validators, and account information. With the Aptos Explorer, you can ensure that the transactions performed on Aptos are accurately reflected. Note, the Aptos ecosystem has [several other explorers](https://aptosfoundation.org/ecosystem/projects/explorers) to choose from.
 
 The Aptos Explorer provides a one-step search engine across the blockchain to discover details about wallets, transactions, network analytics, user accounts, smart contracts, and more. The Aptos Explorer also offers dedicated pages for key elements of the blockchain and acts as the source of truth for all things Aptos. See the [Aptos Glossary](../reference/glossary.md) for definitions of many of the terms found here.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,9 @@ hide_table_of_contents: true
 
 # Aptos Developer Documentation
 
-Welcome! Aptos is a Layer 1 for everyone. In the [Ohlone language](https://en.wikipedia.org/wiki/Ohlone_languages), ["Aptos"](https://en.wikipedia.org/wiki/Aptos,_California) means "The People." This site is here to help you grow a [web3 ecosystem project](https://github.com/aptos-foundation/ecosystem-projects) that benefits the entire world through easier development, more reliable services, faster transactions, and a supportive, decentralized family. 
+Welcome! Aptos is a Layer 1 for everyone. In the [Ohlone language](https://en.wikipedia.org/wiki/Ohlone_languages), ["Aptos"](https://en.wikipedia.org/wiki/Aptos,_California) means "The People."
+
+Our documentation is designed to assist you in developing a [web3 ecosystem project](https://aptosfoundation.org/ecosystem/projects/all) that contributes positively to the global community. We focus on facilitating easier development, ensuring more reliable services, enabling faster transactions, and fostering a supportive, decentralized community.
 
 This documentation will help you develop applications for the Aptos blockchain, run nodes, and be a part of the blossoming Aptos community. This documentation covers both basic and advanced topics. Here you will find concepts, how-to guides, quickstarts, tutorials, API references, code examples, release notes, and more.
 
@@ -130,7 +132,7 @@ The Aptos devnet is reset every Thursday. See the latest updates in the [Aptos D
 
 :::
 
-## Find the ecosystem
+## Engage with the community
 
 We are excited that you are here, and we look forward to getting to know you. Welcome to the Aptos community! Find out more about us and exchange ideas at:
 
@@ -143,6 +145,22 @@ We are excited that you are here, and we look forward to getting to know you. We
 
 ## Community projects on Aptos
 
-Here's a [list of community-maintained projects](https://github.com/aptos-foundation/ecosystem-projects) collected by the [Aptos Foundation](https://aptosfoundation.org/). If you have a project that you want added to the list, just edit the page and add a GitHub pull request.
+Visit [Aptos Ecosystem Projects](https://aptosfoundation.org/ecosystem/projects/all) to discover live projects built on Aptos: 
+
+* [DeFi](https://aptosfoundation.org/ecosystem/projects/defi)
+* [NFT Tooling](https://aptosfoundation.org/ecosystem/projects/nft-tooling)
+* [Gaming](https://aptosfoundation.org/ecosystem/projects/gaming)
+* [Wallets](https://aptosfoundation.org/ecosystem/projects/wallets)
+* [Tooling](https://aptosfoundation.org/ecosystem/projects/tooling)
+* [Stablecoins](https://aptosfoundation.org/ecosystem/projects/stablecoins)
+* [Security](https://aptosfoundation.org/ecosystem/projects/security)
+* [Marketplaces](https://aptosfoundation.org/ecosystem/projects/marketplaces)
+* [Launchpads](https://aptosfoundation.org/ecosystem/projects/launchpads)
+* [Infra](https://aptosfoundation.org/ecosystem/projects/infra)
+* [Explorers](https://aptosfoundation.org/ecosystem/projects/explorers)
+* [Bridges](https://aptosfoundation.org/ecosystem/projects/bridges)
+* [Social](https://aptosfoundation.org/ecosystem/projects/social)
+
+If you would like to showcase your project, please make your submission from the directory.  
 
 Want to pitch in on smaller tasks, such as doc updates and code fixes? See our [Community](./community/index.md) list for opportunities to help the Aptos ecosystem.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -36,7 +36,7 @@ See [Accounts](../concepts/accounts.md) for more information.
 
 ### Aptos
 
-**Aptos** is a Layer 1 blockchain for everyone. It uses the Move programming language and launched its mainnet on 2022-10-17 to redefine the web3 user experience. The Aptos blockchain is dedicated to creating better user experiences through increased speed, security, scalability, reliability and usability with low transaction costs.  The word "Aptos" means "The People" in the Ohlone language. See the [Aptos White Paper](../aptos-white-paper/index.md) for more details.
+**Aptos** is a Layer 1 blockchain for everyone. It uses the Move programming language and launched its mainnet on 2022-10-17 to redefine the web3 user experience. The Aptos blockchain is dedicated to creating better user experiences through increased speed, security, scalability, reliability and usability with low transaction costs.  The word “Aptos" means "The People" in the Ohlone language. Learn more about the Aptos blockchain on the [official Aptos website](https://aptosfoundation.org).
 
 ### AptosBFT
 
@@ -61,7 +61,7 @@ See [Accounts](../concepts/accounts.md) for more information.
 
 ### Aptos Ecosystem
 
-- **Aptos ecosystem** refers to various components of the Aptos blockchain network and their interactions.  The Aptos ecosystem includes the community, community-driven projects, and events. See [Contribute to the Aptos Ecosystem](../community/index.md) for all possible ways to join Aptos.
+- **Aptos ecosystem** refers to various components of the Aptos blockchain network and their interactions.  The Aptos ecosystem includes the community, [community-driven projects](https://aptosfoundation.org/ecosystem/projects/all), and [events](https://aptosfoundation.org/events). See [Contribute to the Aptos Ecosystem](../community/index.md) for all possible ways to join Aptos.
 
 ### Aptos Explorer
 
@@ -182,7 +182,7 @@ then there is a guarantee that T_N will never be included in the blockchain.
 - **Faucet** is a service that mints APT on devnet and testnet. APT on these networks has no real world value, it is only for development purposes.
 - You can use the faucet in a few different ways:
   - With the [Aptos CLI](../tools/aptos-cli/use-cli/use-aptos-cli.md#fund-an-account-with-the-faucet).
-  - Through a wallet, such as Petra, Martian, or Pontem. You can find a full list [here](https://github.com/aptos-foundation/ecosystem-projects#wallets).
+  - Through a wallet, such as [Petra](https://aptosfoundation.org/ecosystem/project/petra), [Martian](https://aptosfoundation.org/ecosystem/project/martian), or [Pontem](https://aptosfoundation.org/ecosystem/project/pontem-wallet). See full list of [Aptos Wallets](https://aptosfoundation.org/ecosystem/projects/wallets).
   - Using an SDK, for example by using the `FaucetClient` in the TypeScript SDK.
   - With a direct HTTP request. Learn how to do this [here](guides/system-integrators-guide.md#calling-the-faucet-other-languages).
 


### PR DESCRIPTION
### Description

- Fix all Ecosystem Projects links from https://github.com/aptos-foundation/ecosystem-projects to https://aptosfoundation.org/ecosystem/projects/all
- Add various Ecosystem Project links to wallets
- Add additional references to aptosfoundation.org
- Adds Ecosystem Project categories to index page
- Canonical tag for whitepaper as it exists at https://aptosfoundation.org/whitepaper to avoid [duplicate content penalty](https://ahrefs.com/seo/glossary/duplicate-content#:~:text=According%20to%20Google%2C%20most%20duplicate,%2C%E2%80%9D%20which%20includes%20scraped%20content.)

### Checklist

- [x] Do all Lints pass?
- [x] Have you ran `pnpm spellcheck`?
- [x] Have you ran `pnpm fmt`?
- [x] Have you ran `pnpm lint`?
