### PR TITLE
[refactor] Remove all references to `developer-docs-site`

### DIFF
--- a/docs/community/aptos-style.md
+++ b/docs/community/aptos-style.md
@@ -64,12 +64,12 @@ Set recursion depth accordingly to delve into sub-links.
 
 ## Add images to `static` directory
 
-Place all images in the [`developer-docs-site/static/img`](https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site/static/img) directory and use relative links to include them. See the image paths in [Set up a React app](../tutorials/build-e2e-dapp/2-set-up-react-app.md) for examples.
+Place all images in the [`static/img`](https://github.com/aptos-labs/developer-docs/tree/main/static/img) directory and use relative links to include them. See the image paths in [Set up a React app](../tutorials/build-e2e-dapp/2-set-up-react-app.md) for examples.
 
 ## Redirect moved pages
 
 Avoid losing users by adding redirects for moved and renamed [Aptos.dev](http://Aptos.dev) pages in:
-https://github.com/aptos-labs/aptos-core/blob/main/developer-docs-site/docusaurus.config.js
+https://github.com/aptos-labs/developer-docs/blob/main/docusaurus.config.js
 
 ## Name files succinctly
 
@@ -103,7 +103,7 @@ Avoid passive tense and gerunds when possible:
     
     - **Preferred**: Fork and clone the Aptos repo.
     - **Avoid**: The Aptos repo should be cloned.
-    - **Preferred**: Copy the `Config path` information from the terminal.
+    - **Preferred**: Copy the `Config path` information from the terminal.
     - **Avoid**: The `Config path` information should be copied from the terminal.
     
 - Avoid hypothetical future "would". Instead, write in present tense.

--- a/docs/community/site-updates.md
+++ b/docs/community/site-updates.md
@@ -16,13 +16,13 @@ Simply click **Edit this page** at the bottom of any location to go to the sourc
 Here are the basic steps for editing in your web browser:
 
 1. Click **Edit this page** at the bottom to get started.
-2. Modify and add source Markdown files in the [developer-docs-site](https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site) directory.
-3. See your changes in Netlify (by swapping `prnumber` in):
+2. Modify and add source Markdown files in the [developer-docs](https://github.com/aptos-labs/developer-docs/tree/docs/) directory.
+3. See your changes in Netlify (by swapping `pull request number` in for `prnumber`):
  [https://deploy-preview-prnumber--aptos-developer-docs.netlify.app/](https://deploy-preview-prnumber--aptos-developer-docs.netlify.app/)
 4. Have at least two verified reviewers examine and test the change.
 5. Merge in the change and see it go live.
 
-For more complex documentation updates, we recommend [forking the repository](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#developer-workflow) and using a local editor to make changes. To edit at the command line and preview your changes on your localhost, see our [Developer Documentation](https://github.com/aptos-labs/aptos-core/blob/main/developer-docs-site/README.md) README.
+For more complex documentation updates, we recommend [forking the repository](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#developer-workflow) and using a local editor to make changes. To edit at the command line and preview your changes on your localhost, see our [Developer Documentation](https://github.com/aptos-labs/developer-docs/blob/main/README.md) README.
 
 When ready, [start a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) with your changes. We will get back to you shortly.
 
@@ -43,17 +43,17 @@ Whenever possible, update [Aptos.dev](http://Aptos.dev) directly to reflect your
 
 To update [Aptos.dev](http://Aptos.dev) directly:
 
-1. Trigger an edit to the source files in the [developer-docs-site](https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site) directory:
+1. Trigger an edit to the source files in the [developer-docs](https://github.com/aptos-labs/developer-docs/tree/main) directory:
     1. In web browser:
        * for simple, one-page changes, use the ***Edit this page*** link on the bottom of any page to access the source Markdown file in GitHub:
        ![v-fn-network.svg](../../static/img/docs/trigger-edits-aptosdev.png)
          Then click the pencil icon and select **Edit this file** to work in the GitHub web editor, and create a pull request to have it reviewed:
        ![v-fn-network.svg](../../static/img/docs/edit-file-in-GH.png)
-       * To add a new page, navigate to the relevant subdirectory of the [developer-docs-site/docs/](https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site/docs/) directory, click **Add file**, give it a name, append the `.md` file extension, include your contents, and create a pull request to have it reviewed:
+       * To add a new page, navigate to the relevant subdirectory of the [developer-docs/docs/](https://github.com/aptos-labs/aptos-core/tree/main/developer-docs/docs/) directory, click **Add file**, give it a name, append the `.md` file extension, include your contents, and create a pull request to have it reviewed:
        ![v-fn-network.svg](../../static/img/docs/add-file-in-GH.png)
     2. Via local editor - for more complex, multipage changes, use your preferred source code editor to navigate to and update the source Markdown files in GitHub. See our [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) README for `git clone` instructions.
 2. For web edits, use the *Preview* function at top to see your updates in browser.
-3. For local edits, use the [local doc build instructions](https://github.com/aptos-labs/aptos-core/blob/main/developer-docs-site/README.md) to see your updates at: [http://localhost:3000](http://localhost:3000)
+3. For local edits, use the [local doc build instructions](https://github.com/aptos-labs/developer-docs/blob/main/README.md) to see your updates at: [http://localhost:3000](http://localhost:3000)
 4. After creating the pull request, use the *Deploy Preview* in Netlify to see your updates made in web browser or via local editor by replacing the *pull request number* with your own in:
 [https://deploy-preview-prnumber--aptos-developer-docs.netlify.app/](https://deploy-preview-prnumber--aptos-developer-docs.netlify.app/)
 5. Have at least two verified reviewers review and test your changes.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # Scripts
 ## Spellchecking
-In order to spell check, you just need to run this from anywhere in `developer-docs-site/`:
+In order to spell check, you just need to run this from anywhere in `developer-docs`:
 ```
 pnpm spellcheck
 ```

--- a/scripts/spellcheck.sh
+++ b/scripts/spellcheck.sh
@@ -37,7 +37,7 @@ done
 if [ $everything_spelled_correctly -eq 0 ]
 then
     echo "Misspelled words were found 😭"
-    echo "If the typo is not actually a typo, add the word to developer-docs-site/scripts/additional_dict.txt"
+    echo "If the typo is not actually a typo, add the word to scripts/additional_dict.txt"
     echo
     exit 1
 else

--- a/static/move-examples/move-tutorial/README.md
+++ b/static/move-examples/move-tutorial/README.md
@@ -7,7 +7,7 @@ slug: "move-tutorial"
 
 Welcome to the Aptos Move Tutorial! This is the original Move language and tools tutorial, independent of a particular network, adapted to use Aptos tooling. Here you will learn basic usage of the Move language and tools for compiling, testing, and verifying Move.
 
-This tutorial does not teach you how to use the existing [Aptos Move frameworks](https://aptos.dev/reference/move) or how to run code on the Aptos network. See the [Aptos developer documentation](../../../developer-docs-site/docs/tutorials/index.md) for those instructions.
+This tutorial does not teach you how to use the existing [Aptos Move frameworks](https://aptos.dev/reference/move) or how to run code on the Aptos network. See the [Aptos developer documentation](../../../docs/tutorials/index.md) for those instructions.
 
 There are nine steps in total:
 
@@ -35,7 +35,7 @@ You should obtain a copy of the content of the directory in which this `README.m
 step_1 step_2 step_2_sol step_3 ...
 ```
 
-You also need a recent version of the [Aptos CLI](../../../developer-docs-site/docs/tools/aptos-cli/install-cli/index.md). This tutorial is written using the following version:
+You also need a recent version of the [Aptos CLI](../../../docs/tools/aptos-cli/install-cli/index.md). This tutorial is written using the following version:
 
 ```shell
 > aptos --version
@@ -67,13 +67,13 @@ module 0xCAFE::basic_coin {
 ```
 
 This is defining a Move
-[module](../../../developer-docs-site/docs/move/book/modules-and-scripts.md). Modules are the
+[module](../../../docs/move/book/modules-and-scripts.md). Modules are the
 building blocks of Move code, and are defined with a specific address -- the
 address that the module can be published under. In this case, the `basic_coin`
 module can be published only under `0xCAFE`.
 
 Let's now take a look at the next part of this file where we define a
-[struct](../../../developer-docs-site/docs/move/book/structs-and-resources.md)
+[struct](../../../docs/move/book/structs-and-resources.md)
 to represent a `Coin` with a given `value`:
 
 ```
@@ -100,7 +100,7 @@ module 0xCAFE::basic_coin {
 ```
 
 Let us take a look at this function and what it is saying:
-* It takes a [`&signer`](../../../developer-docs-site/docs/move/book/signer.md) reference ('`&`') -- an
+* It takes a [`&signer`](../../../docs/move/book/signer.md) reference ('`&`') -- an
   unforgeable token that represents control over a particular address, and
   a `value` to mint.
 * It creates a `Coin` with the given value and stores it under the
@@ -120,11 +120,11 @@ aptos move compile
     aptos move init --name <pkg_name>
     ```
 * Move code can also live in a number of other places. See the [Move
-  book](../../../developer-docs-site/docs/move/book/packages.md) for more information on the
+  book](../../../docs/move/book/packages.md) for more information on the
   Move package system.
-* More information on the `Move.toml` file can also be found in the [Package](../../../developer-docs-site/docs/move/book/packages.md#movetoml) section of the Move book.
+* More information on the `Move.toml` file can also be found in the [Package](../../../docs/move/book/packages.md#movetoml) section of the Move book.
 * Move also supports the idea of [named
-  addresses](../../../developer-docs-site/docs/move/book/address.md#named-addresses); Named
+  addresses](../../../docs/move/book/address.md#named-addresses); Named
   addresses are a way to parameterize Move source code so that you can compile
   the module using different values for `named_addr` to get different bytecode
   that you can deploy, depending on what address(es) you control. They are used quite frequently, and can be defined in the `Move.toml` file in the `[addresses]` section, like so:
@@ -132,9 +132,9 @@ aptos move compile
     [addresses]
     Somenamed_address = "0xC0FFEE"
     ```
-* [Structures](../../../developer-docs-site/docs/move/book/structs-and-resources.md) in Move
+* [Structures](../../../docs/move/book/structs-and-resources.md) in Move
   can be given different
-  [abilities](../../../developer-docs-site/docs/move/book/abilities.md) that describe what
+  [abilities](../../../docs/move/book/abilities.md) that describe what
   can be done with that type. There are four different abilities:
     - `copy`: Allows values of types with this ability to be copied.
     - `drop`: Allows values of types with this ability to be popped/dropped.
@@ -145,12 +145,12 @@ aptos move compile
     in global storage and, because it has no other abilities, it cannot be
     copied, dropped, or stored as a non-key value in storage. So you can't copy
     coins, and you also can't lose coins by accident!
-* [Functions](../../../developer-docs-site/docs/move/book/functions.md) are default
+* [Functions](../../../docs/move/book/functions.md) are default
     private, and can also be `public`,
-    [`public(friend)`](../../../developer-docs-site/docs/move/book/friends.md).
+    [`public(friend)`](../../../docs/move/book/friends.md).
     A function marked as `entry` can be called as a transaction.
 * `move_to` is one of the [five different global storage
-  operators](../../../developer-docs-site/docs/move/book/global-storage-operators.md).
+  operators](../../../docs/move/book/global-storage-operators.md).
 </details>
 
 ## Step 2: Adding unit tests to my first Move module<span id="Step2"><span>
@@ -291,7 +291,7 @@ method directly from a transaction, you'll want to change its signature to:
 ```
 public entry fun transfer(from: signer, to: address, amount: u64) acquires Balance { ... }
 ```
-Read more on Move function [visibilities](../../../developer-docs-site/docs/move/book/functions.md#visibility).
+Read more on Move function [visibilities](../../../docs/move/book/functions.md#visibility).
 </details>
 <details>
 <summary>Comparison with Ethereum/Solidity</summary>
@@ -348,7 +348,7 @@ is false, then abort the transaction with `<abort_code>`. Here `MODULE_OWNER` an
 defined at the beginning of the module. The standard library's [`error`] module also defines common error categories we can use.
 
 It is important to note that Move is transactional in its execution -- so
-if an [abort](../../../developer-docs-site/docs/move/book/abort-and-assert.md) is raised no unwinding of state
+if an [abort](../../../docs/move/book/abort-and-assert.md) is raised no unwinding of state
 needs to be performed, as no changes from that transaction will be persisted to the blockchain.
 
 [`error` module]: https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/move-stdlib/sources/error.move
@@ -385,7 +385,7 @@ fun withdraw(addr: address, amount: u64) : Coin acquires Balance {
 }
 ```
 At the beginning of the method, we assert that the withdrawing account has enough balance. We then use `borrow_global_mut`
-to get a mutable reference to the global storage, and `&mut` is used to create a mutable [reference](../../../developer-docs-site/docs/move/book/references.md) to a field of a
+to get a mutable reference to the global storage, and `&mut` is used to create a mutable [reference](../../../docs/move/book/references.md) to a field of a
 struct. We then modify the balance through this mutable reference and return a new coin with the withdrawn amount.
 </details>
 
@@ -446,7 +446,7 @@ The solution to this exercise can be found in [`step_5_sol`](./step_5_sol).
 ## Step 6: Making my `basic_coin` module generic<span id="Step6"><span>
 
 In Move, we can use
-[generics](../../../developer-docs-site/docs/move/book/generics.md)
+[generics](../../../docs/move/book/generics.md)
 to define functions and structs over different input data types. Generics are a great
 building block for library code. In this section, we are going to make our simple
 `basic_coin` module generic so that it can serve as a library module to be used by
@@ -487,17 +487,17 @@ In definitions of both `Coin` and `Balance`, we declare the type parameter `Coin
 to be phantom because `CoinType` is not used in the struct definition or is only used as a phantom type
 parameter.
 
-Read more about [phantom type](../../../developer-docs-site/docs/move/book/generics.md#phantom-type-parameters) parameters in the Aptos Move Book.
+Read more about [phantom type](../../../docs/move/book/generics.md#phantom-type-parameters) parameters in the Aptos Move Book.
 </details>
 
 ## Step 7:  Use the Move Prover
     
-> NOTE: Before running the Move Prover, ensure that the [Move Prover](../../../developer-docs-site/docs/tools/aptos-cli/install-cli/install-move-prover.md) and associated tools are installed.
+> NOTE: Before running the Move Prover, ensure that the [Move Prover](../../../docs/tools/aptos-cli/install-cli/install-move-prover.md) and associated tools are installed.
 
 Smart contracts deployed on the blockchain may manipulate high-value assets. As a technique that uses strict
 mathematical methods to describe behavior and reason correctness of computer systems, formal verification
 has been used in blockchains to prevent bugs in smart contracts. The
-[Move Prover](../../../developer-docs-site/docs/move/prover/index.md)
+[Move Prover](../../../docs/move/prover/index.md)
 is an evolving formal verification tool for smart contracts written in the Move language. The user can employ the 
 [Move Prover](https://github.com/move-language/move/blob/main/language/move-prover/doc/user/prover-guide.md) to specify
 functional properties of smart contracts

--- a/static/sdks/python/README.md
+++ b/static/sdks/python/README.md
@@ -49,7 +49,7 @@ Finally run the tests:
 make examples
 ```
 
-Note: These end-to-end tests are tested against a node built from the same commit as part of CI, not devnet. For examples tested against devnet, see `developer-docs-site/static/examples/python/` from the root of the repo.
+Note: These end-to-end tests are tested against a node built from the same commit as part of CI, not devnet. For examples tested against devnet, see `static/examples/python/` from the root of the repo.
 
 ## Autoformatting
 ```bash


### PR DESCRIPTION
### Description
Renames developer-docs-site -> developer-docs, fixes git references.

### Checklist

- [x] Do all Lints pass?
- [x] Have you ran `pnpm spellcheck`?
- [x] Have you ran `pnpm fmt`?
- [x] Have you ran `pnpm lint`?
