### PR TITLE
update fullnode release docs to clarify data wipe requirement

### DIFF
--- a/docs/nodes/full-node/fullnode-source-code-or-docker.md
+++ b/docs/nodes/full-node/fullnode-source-code-or-docker.md
@@ -238,7 +238,7 @@ aptos_connections{direction="outbound",network_id="Public",peer_id="aabd651f",ro
 
 If the number of outbound connections returned is `0`, then it means your node cannot connect to the Aptos blockchain. If this happens to you, follow these steps to resolve the issue:
 
-1. Update your node to the latest release by following the [Update Fullnode With New Devnet Releases](./update-fullnode-with-new-releases.md).
+1. Update your node to the latest release by following the [Update Fullnode With New Releases](./update-fullnode-with-new-releases.md).
 2. Remove any `seed` peers you may have added to your `public_full_node.yaml` configuration file. The seeds may be preventing you from connecting to the network. Seed peers are discussed in the [Connecting your fullnode to seed peers](./fullnode-network-connections.md#connecting-your-fullnode-to-seed-peers) section.
 
 ### (Optional) Examine Docker ledger size
@@ -263,47 +263,3 @@ du -cs -BM /opt/aptos/data
 [devnet_waypoint]: https://devnet.aptoslabs.com/waypoint.txt
 [aptos-labs/aptos-core]: https://github.com/aptos-labs/aptos-core.git
 [status dashboard]: https://status.devnet.aptos.dev
-
-## Upgrade your public fullnode
-
-When receiving an update from Aptos for your fullnode, take these measures to minimize downtime. In all cases, you are essentially undoing setup and restarting anew. So first make sure your development environment is up to date.
-
-### Upgrading from source
-
-If you created your Aptos fullnode from source, you should similarly upgrade from source:
-
-1. Stop your local public fullnode by running the below command:
-
-```bash
-cargo stop aptos-node
-```
-
-1. Delete the `waypoint.txt`, `genesis.blob` and `fullnode.yaml` files previously downloaded, installed and configured.
-1. Re-install and configure those files as during setup.
-1. Restart your local public fullnode by running the same start (`run`) command as before:
-
-```bash
-cargo run -p aptos-node --release -- -f ./fullnode.yaml
-```
-
-### Upgrading with Docker
-
-If you created your Aptos fullnode with Docker, you should similarly upgrade with Docker:
-
-1. Stop your local public fullnode by running the below command:
-   ```bash
-   docker-compose down --volumes
-   ```
-1. Delete the `waypoint.txt`, `genesis.blob` and `fullnode.yaml` files previously downloaded, installed and configured.
-1. Re-install and configure those files as during setup.
-1. Restart your local public fullnode by running the same start (`run`) command as before:
-
-```bash
-docker run --pull=always \
-    --rm -p 8080:8080 \
-    -p 9101:9101 -p 6180:6180 \
-    -v $(pwd):/opt/aptos/etc -v $(pwd)/data:/opt/aptos/data \
-    --workdir /opt/aptos/etc \
-    --name=aptos-fullnode aptoslabs/validator:mainnet aptos-node \
-    -f /opt/aptos/etc/fullnode.yaml
-```

--- a/docs/nodes/full-node/update-fullnode-with-new-releases.md
+++ b/docs/nodes/full-node/update-fullnode-with-new-releases.md
@@ -1,47 +1,72 @@
 ---
-title: "Update Fullnode With New Devnet Releases"
+title: "Update Fullnode With New Releases"
 slug: "update-fullnode-with-new-devnet-releases"
 sidebar_position: 11
 ---
 
 # Update Fullnode With New Releases
 
-When `devnet` is wiped and updated with newer versions, you will need to update your fullnode as well. If you do not, your fullnode will not continue to synchronize with the network. To update your fullnode, follow these steps:
+This document outlines the process for updating your fullnode. For fullnodes running in `devnet`, an additional data wipe step is required as `devnet` is wiped on every release.
 
 ## If you built the fullnode from aptos-core source code
 
-1. Shutdown your fullnode.
+1. Stop your fullnode by running the below command:
 
-2. Delete the data folder (the directory path is what you specified in the configuration file, e.g., `fullnode.yaml`).
+```bash
+cargo stop aptos-node
+```
+
+2. For users of the Rust binary, pull the latest release appropriate for your network (`devnet`, `testnet`, or `mainnet`):
+
+```bash
+git checkout [network_branch] && git pull
+```
+
+Replace `[network_branch]` with `devnet`, `testnet`, or `mainnet` as applicable, and rebuild the binary.
+
+3. If your fullnode is running in `devnet`, follow the additional steps in the [Additional data wipe steps for `devnet`](#additional-data-wipe-steps-for-devnet) section below.
+
+4. Restart your fullnode by running the same start (`run`) command as before:
+
+```bash
+cargo run -p aptos-node --release -- -f ./fullnode.yaml
+```
+
+5. See the [Verify initial synchronization](./fullnode-source-code-or-docker.md#verify-initial-synchronization) section for checking if the fullnode is syncing again.
+
+### Additional data wipe steps for `devnet`
+
+For devnet, follow these additional steps after stopping your fullnode:
+
+1. Delete the data folder (the directory path is what you specified in the configuration file, e.g., `fullnode.yaml`).
 
    - The default data folder is `/opt/aptos/data`.
 
-3. Delete the `genesis.blob` file and `waypoint.txt` file (depending on how you configured it, you might not have this file and may instead have a `waypoint` directly in your configuration file).
+2. Delete the `genesis.blob` file and `waypoint.txt` file (depending on how you configured it, you might not have this file and may instead have a `waypoint` directly in your configuration file).
 
-4. If you use the Rust binary, pull the latest of `devnet` via `git checkout devnet && git pull`, and build the binary again.
+3. Download the new [genesis.blob](../node-files-all-networks/node-files.md#genesisblob) file and the new [waypoint](../node-files-all-networks/node-files.md#waypointtxt).
 
-5. Download the new [genesis.blob](../node-files-all-networks/node-files.md#genesisblob) file and the new [waypoint](../node-files-all-networks/node-files.md#waypointtxt).
-
-6. Update the configuration file (e.g., `fullnode.yaml`) with the new waypoint (if you configure the waypoint directly there).
-
-7. Restart the fullnode.
-
-8. See the [Verify initial synchronization](./fullnode-source-code-or-docker.md#verify-initial-synchronization) section for checking if the fullnode is syncing again.
+4. Update the configuration file (e.g., `fullnode.yaml`) with the new waypoint (if you configure the waypoint directly there).
 
 ## If you run a fullnode via Docker
 
-1. Shutdown your fullnode
-2. Delete the entire directory which holds your fullnode config and data directory.
-3. Rerun the instructions on [Approach #2: Using Docker](./fullnode-source-code-or-docker.md#Approach-#2:-Using-Docker)
+1. Stop your fullnode by running the below command:
+   ```bash
+   docker compose down --volumes
+   ```
+2. If your fullnode is running in `devnet`, delete the entire directory which holds your fullnode config and data directory.
+3. Re-install and configure those files as during setup.
+4. Restart your fullnode:
+
+```bash
+docker compose up -d
+```
 
 ## If you run a fullnode on GCP
 
-Aptos devnet releases can be of two types:
+### Upgrade with data wipe (devnet only)
 
-- One with a data wipe to start over the Aptos blockchain
-- Second type is only a software update without a data wipe
-
-### Upgrade with data wipe
+Upgrading your node in devnet requires a data wipe, as the network is reset on each deployment. Other networks (e.g., testnet and mainnet) don't require this step and we recommend not wiping your data in these networks.
 
 1. You can increase the `era` number in `main.tf` to trigger a new data volume creation, which will start the node on a new DB.
 

--- a/docs/nodes/nodes-landing.md
+++ b/docs/nodes/nodes-landing.md
@@ -156,7 +156,7 @@ the [external resources](../community/external-resources.md) offered by your fel
             </div>
             <small>Create a static network identity for your fullnode.</small>
           </a>
-          <a href="./full-node/update-fullnode-with-new-devnet-releases" class="list-group-item">
+          <a href="./full-node/update-fullnode-with-new-releases" class="list-group-item">
             <div class="d-flex w-100 justify-content-between">
               <h4 class="mb-1">Update fullnode</h4>
             </div>


### PR DESCRIPTION
### Description
Update the docs to consolidate some duplicate upgrade instructions for fullnodes. Also added clarification that wipes are only necessary for devnet

This was copied from:
https://github.com/aptos-labs/aptos-core/pull/11181

### Checklist

- [] Do all Lints pass?
- [] Have you ran `pnpm spellcheck`?
- [] Have you ran `pnpm fmt`?
- [] Have you ran `pnpm lint`?
