### PR TITLE
[move-reference] Load page anchors after dynamic page load

### DIFF
--- a/src/components/MoveReference/index.tsx
+++ b/src/components/MoveReference/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import BrowserOnly from "@docusaurus/BrowserOnly";
-
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
@@ -116,7 +115,16 @@ const SideNav = ({ branch }: SideNavProps) => {
       }
     };
 
-    fetchContent().catch((err) => console.log(`Error fetching spec: ${err}`));
+    fetchContent()
+      .catch((err) => console.log(`Error fetching spec: ${err}`))
+      .then(() => {
+        // Load the requested hash after the page has been dynamically loaded
+        if (location.hash) {
+          let requested_hash = location.hash.slice(1);
+          location.hash = "";
+          location.hash = requested_hash;
+        }
+      });
     return () => {
       isMounted = false;
     };
@@ -182,6 +190,8 @@ const Content = ({ branch, page }: ContentProps) => {
     };
 
     fetchContent().catch((err) => console.log(`Error fetching spec: ${err}`));
+    // I've fetched the content, to ensure it's pointing to the right place do a redirect
+    console.log("LOCATION: ", window.location.href);
     return () => {
       isMounted = false;
     };


### PR DESCRIPTION
### Description
Dynamic page loads screwed with the anchors, and didn't load them appropriately.  This should load things after page load

Thanks stack overflow https://stackoverflow.com/questions/36337703/reliably-jumping-to-named-anchor-on-dynamically-generated-page

Example:

https://deploy-preview-28--aptos-developer-docs.netlify.app/reference/move/?branch=mainnet&page=aptos-framework/doc/account.md#0x1_account_create_account_if_does_not_exist

### Checklist

- [x] Do all Lints pass?
- [x] Have you ran `pnpm spellcheck`?
- [x] Have you ran `pnpm fmt`?
- [x] Have you ran `pnpm lint`?
