### PR TITLE
[move-reference-doc][trivial] make id work in anchor

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1243,7 +1243,7 @@ html[data-theme='dark'] .sidebar-divider {
   width: 80%;
 }
 
-.move-content a[name] {
+.move-content a[name], .move-content a[id] {
   scroll-margin-top: calc(var(--ifm-navbar-height) + 0.5rem);
 }
 


### PR DESCRIPTION
### Description

In this [PR](https://github.com/aptos-labs/aptos-core/pull/11003), we replaced "name" with "id" in anchors for the markdown files. In order to make the jump work for those anchors, the css file needs to be updated.

### Checklist

- [] Do all Lints pass?
- [] Have you ran `pnpm spellcheck`?
- [] Have you ran `pnpm fmt`?
- [] Have you ran `pnpm lint`?
