### PR TITLE
Documentation Corrections and Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This Aptos Developer Documentation is built using [Docusaurus 2](https://docusaurus.io/) and displayed on https://aptos.dev/. Follow the below steps to build the docs locally and test your contribution.
 
-We now use [lychee-broken-link-checker](https://github.com/marketplace/actions/lychee-broken-link-checker) to check for broken links in the GitHub Markdown. We are a corresponding link checker for pages on Aptos.dev.
+We now use [lychee-broken-link-checker](https://github.com/marketplace/actions/lychee-broken-link-checker) to check for broken links in the GitHub Markdown. We use a corresponding link checker for pages on Aptos.dev.
 
 With results visible at:
 https://github.com//aptos-labs/developer-docs/actions/workflows/links.yml

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ This step will configure the Docusaurus static site generator.
 pnpm start
 ```
 
-4. See your changes staged at: http://localhost:3000/
+3. See your changes staged at: http://localhost:3000/
 
-5. Create a pull request with your changes as described in our [Contributing](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) README.
+4. Create a pull request with your changes as described in our [Contributing](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) README.
 
 ## (Optional) Build static html files
 

--- a/docs/reference/telemetry.md
+++ b/docs/reference/telemetry.md
@@ -74,6 +74,6 @@ All the below variables are set by default to `false`, i.e., sending of these te
 - `APTOS_FORCE_ENABLE_TELEMETRY`: This overrides the chain ID check and forces the node to send telemetry regardless of whether remote service accepts or not.
 - `APTOS_DISABLE_TELEMETRY_PUSH_METRICS`: This disables sending the [Prometheus](https://prometheus.io/) metrics.
 - `APTOS_DISABLE_TELEMETRY_PUSH_LOGS`: This disables sending the logs.
-- `APTOS_DISBALE_TELEMETRY_PUSH_EVENTS`: This disables sending the custom events.
+- `APTOS_DISABLE_TELEMETRY_PUSH_EVENTS`: This disables sending the custom events.
 - `APTOS_DISABLE_LOG_ENV_POLLING`: This disables the dynamic ability to send verbose logs.
 - `APTOS_DISABLE_PROMETHEUS_NODE_METRICS`: This disables sending the node resource metrics such as system CPU, memory, etc.


### PR DESCRIPTION
I am submitting a few updates to the Aptos Developer Documentation, aimed at refining its accuracy and clarity. Below is a brief overview of the changes:

1. **Correction of Environment Variable in Telemetry Documentation (Commit: bd65d2e)**
   - Addressed a discrepancy in the `telemetry.md` file. The documentation incorrectly listed `APTOS_DISBALE_TELEMETRY_PUSH_EVENTS` instead of the correct variable `APTOS_DISABLE_TELEMETRY_PUSH_EVENTS`, as consistently used in the `aptos-core` codebase (`service.rs` and `constants.rs`). This amendment aligns the documentation with the actual implementation in the repository.

2. **Revision of Step Numbering in README (Commit: bd12b36)**
   - Updated the step numbering in the 'Build and serve the docs locally' section of the `README.md` for better clarity and logical sequence. 

3. **Clarification in README Regarding Link Checker (Commit: eb274279)**
   - Enhanced the sentence structure related to the link checker tool used for Aptos.dev pages in the README. This revision improves the clarity of the tool's application and purpose.

Thank you for considering these updates. I appreciate the opportunity to contribute to the continual improvement of the documentation.