### PR TITLE
Fix missing titles, remove slugs where redundant

### DIFF
--- a/docs/apis/fullnode-rest-api.md
+++ b/docs/apis/fullnode-rest-api.md
@@ -1,6 +1,5 @@
 ---
 title: "Fullnode Rest API"
-slug: "fullnode-rest-api"
 ---
 
 # Use the Aptos Fullnode REST API

--- a/docs/community/aptos-style.md
+++ b/docs/community/aptos-style.md
@@ -1,6 +1,5 @@
 ---
 title: "Follow Aptos Style"
-slug: "aptos-style"
 ---
 
 # Follow Aptos Writing Style

--- a/docs/community/external-resources.md
+++ b/docs/community/external-resources.md
@@ -1,6 +1,5 @@
 ---
 title: "External Resources"
-slug: "external-resources"
 ---
 
 # Aptos External Resources

--- a/docs/community/site-updates.md
+++ b/docs/community/site-updates.md
@@ -1,6 +1,5 @@
 ---
 title: "Update Aptos.dev"
-slug: "site-updates"
 ---
 
 # Update Aptos.dev

--- a/docs/concepts/blockchain.md
+++ b/docs/concepts/blockchain.md
@@ -1,12 +1,9 @@
 ---
 title: "Aptos Blockchain Deep Dive"
-slug: "blockchain"
 ---
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-
-# Aptos Blockchain Deep Dive
 
 For a deeper understanding of the lifecycle of an Aptos transaction (from an operational perspective), we will follow a transaction on its journey, from being submitted to an Aptos fullnode, to being committed to the Aptos blockchain. We will then focus on the logical components of Aptos nodes and take a look at how the transaction interacts with these components.
 

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -1,11 +1,10 @@
 ---
 title: "Events"
-slug: "events"
 ---
 
 Events are emitted during the execution of a transaction. Each Move module can define its own events and choose when to emit the events upon execution of the module. Aptos Move supports two form of events: module events and EventHandle events. Module events are the modern event mechanism and shipped in the framework release 1.7. EventHandle events are deprecated and shipped with the original framework. Because of how blockchains work, EventHandle events will likely never be fully removed from Aptos.
 
-# Module Events
+## Module Events
 
 Module events are global event streams identified by a struct type. To define an event struct, add the attribute `#[event]` to a normal Move struct that has `drop` and `store` abilities. For example,
 

--- a/docs/concepts/fullnodes.md
+++ b/docs/concepts/fullnodes.md
@@ -1,6 +1,5 @@
 ---
 title: "Fullnodes Overview"
-slug: "fullnodes"
 ---
 
 An Aptos node is an entity of the Aptos ecosystem that tracks the [state](../reference/glossary.md#state) of the Aptos blockchain. Clients interact with the blockchain via Aptos nodes. There are two types of nodes:

--- a/docs/concepts/gas-txn-fee.md
+++ b/docs/concepts/gas-txn-fee.md
@@ -1,9 +1,6 @@
 ---
 title: "Gas and Storage Fees"
-slug: "gas-txn-fee"
 ---
-
-# Gas and Storage Fees
 
 Any transaction execution on the Aptos blockchain requires a processing fee. As of today, this fee comprises two components:
 

--- a/docs/concepts/governance.md
+++ b/docs/concepts/governance.md
@@ -1,12 +1,9 @@
 ---
 title: "Governance"
-slug: "governance"
 ---
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-
-# Governance
 
 The Aptos on-chain governance is a process by which the Aptos community members can create and vote on proposals that minimize the cost of blockchain upgrades. The following describes the scope of these proposals for the Aptos on-chain governance:
 

--- a/docs/concepts/node-networks-sync.md
+++ b/docs/concepts/node-networks-sync.md
@@ -1,6 +1,5 @@
 ---
 title: "Node Networks and Sync"
-slug: "node-networks-sync"
 ---
 
 # Node Networks and Synchronization

--- a/docs/concepts/staking.md
+++ b/docs/concepts/staking.md
@@ -1,12 +1,9 @@
 ---
 title: "Staking"
-slug: "staking"
 ---
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-
-# Staking
 
 :::tip Consensus
 We strongly recommend that you read the consensus section of [Aptos Blockchain Deep Dive](./blockchain.md#consensus) before proceeding further.

--- a/docs/concepts/txns-states.md
+++ b/docs/concepts/txns-states.md
@@ -1,12 +1,9 @@
 ---
 title: "Transactions and States"
-slug: "txns-states"
 ---
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-
-# Transactions and States
 
 The Aptos blockchain stores three types of data:
 

--- a/docs/concepts/validator-nodes.md
+++ b/docs/concepts/validator-nodes.md
@@ -1,6 +1,5 @@
 ---
 title: "Validator Nodes Overview"
-slug: "validator-nodes"
 ---
 
 import BlockQuote from "@site/src/components/BlockQuote";
@@ -22,7 +21,7 @@ Each Aptos node comprises several logical components:
 
 The [Aptos-core](../reference/glossary.md#aptos-core) software can be configured to run as a validator node or as a fullnode.
 
-# Overview
+## Overview
 
 When a transaction is submitted to the Aptos blockchain, validator nodes run a distributed [consensus protocol](../reference/glossary.md#consensus-protocol), execute the transaction, and store the transaction and the execution results on the blockchain. Validator nodes decide which transactions will be added to the blockchain and in which order.
 

--- a/docs/guides/data-pruning.md
+++ b/docs/guides/data-pruning.md
@@ -1,9 +1,6 @@
 ---
 title: "Data Pruning"
-slug: "data-pruning"
 ---
-
-# Data Pruning
 
 When a validator node is running, it participates in consensus to execute
 transactions and commit new data to the blockchain. Similarly, when fullnodes

--- a/docs/guides/explore-aptos.md
+++ b/docs/guides/explore-aptos.md
@@ -1,6 +1,5 @@
 ---
 title: "Explore Aptos"
-slug: "explore-aptos"
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/guides/state-sync.md
+++ b/docs/guides/state-sync.md
@@ -1,12 +1,9 @@
 ---
 title: "State Synchronization"
-slug: "state-sync"
 ---
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-
-# State Synchronization
 
 Nodes in an Aptos network (e.g., validator nodes and fullnodes) must always be synchronized to the latest Aptos blockchain state. The [state synchronization](https://medium.com/aptoslabs/the-evolution-of-state-sync-the-path-to-100k-transactions-per-second-with-sub-second-latency-at-52e25a2c6f10) (state sync) component that runs on each node is responsible for this. State sync identifies and fetches new blockchain data from the peers, validates the data and persists it to the local storage.
 

--- a/docs/guides/system-integrators-guide.md
+++ b/docs/guides/system-integrators-guide.md
@@ -1,6 +1,5 @@
 ---
 title: "Integrate with Aptos"
-slug: "system-integrators-guide"
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/indexer/legacy/indexer-fullnode.md
+++ b/docs/indexer/legacy/indexer-fullnode.md
@@ -1,6 +1,5 @@
 ---
 title: "Run an Indexer Fullnode"
-slug: "indexer-fullnode"
 ---
 
 :::warning Legacy Indexer

--- a/docs/move/move-on-aptos/modules-on-aptos.md
+++ b/docs/move/move-on-aptos/modules-on-aptos.md
@@ -1,9 +1,6 @@
 ---
 title: "Modules on Aptos"
-slug: "modules-on-aptos"
 ---
-
-# Modules on Aptos
 
 Aptos allows for permissionless publishing of [modules](../book/modules-and-scripts.md) within a [package](../book/packages.md) as well as [upgrading](../book/package-upgrades.md) those that have appropriate compatibility policy set.
 

--- a/docs/move/move-on-aptos/move-scripts.md
+++ b/docs/move/move-on-aptos/move-scripts.md
@@ -1,6 +1,5 @@
 ---
 title: "Move Scripts"
-slug: "move-scripts"
 ---
 
 # Move Scripts

--- a/docs/move/move-on-aptos/resource-accounts.md
+++ b/docs/move/move-on-aptos/resource-accounts.md
@@ -1,6 +1,5 @@
 ---
 title: "Resource Accounts"
-slug: "resource-accounts"
 ---
 
 # Resource Accounts

--- a/docs/move/prover/prover-guide.md
+++ b/docs/move/prover/prover-guide.md
@@ -1,9 +1,6 @@
 ---
 title: "Move Prover User Guide"
-slug: "prover-guide"
 ---
-
-# Move Prover User Guide
 
 This is the user guide for the Move Prover. This document accompanies the
 [Move specification language](spec-lang.md). See the sections below for details.

--- a/docs/move/prover/spec-lang.md
+++ b/docs/move/prover/spec-lang.md
@@ -1,9 +1,6 @@
 ---
 title: "Move Specification Language"
-slug: "spec-lang"
 ---
-
-# Move Specification Language
 
 This document describes the _Move specification language (MSL)_, a subset of the [Move](../move-on-aptos.md) language that supports specification of the behavior of Move programs. MSL works together with the [Move Prover](./index.md), a tool that can statically verify the correctness of MSL specifications against Move programs. In contrast to traditional testing, verification of MSL is exhaustive and holds for all possible inputs and global states of a [Move module](../../reference/glossary.md#move-module) or [transaction script](../../reference/glossary.md#transaction-or-move-script). At the same time, this verification of MSL is fast and automated enough that it can be used at a similar place in the developer workflow where tests are typically conducted (for example, for qualification of pull requests in continuous integration).
 

--- a/docs/move/prover/supporting-resources.md
+++ b/docs/move/prover/supporting-resources.md
@@ -1,6 +1,5 @@
 ---
 title: "Supporting Resources"
-slug: "supporting-resources"
 ---
 
 # Move Prover Supporting Resources

--- a/docs/nodes/full-node/bootstrap-fullnode.md
+++ b/docs/nodes/full-node/bootstrap-fullnode.md
@@ -1,6 +1,5 @@
 ---
 title: "Bootstrap Fullnode from Snapshot"
-slug: "bootstrap-fullnode"
 sidebar_position: 14
 ---
 

--- a/docs/nodes/identity-and-configuration.md
+++ b/docs/nodes/identity-and-configuration.md
@@ -1,6 +1,5 @@
 ---
 title: "Identity and Configuration"
-slug: "identity-and-configuration"
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/docs/nodes/leaderboard-metrics.md
+++ b/docs/nodes/leaderboard-metrics.md
@@ -1,9 +1,6 @@
 ---
 title: "Leaderboard Metrics"
-slug: "leaderboard-metrics"
 ---
-
-# Leaderboard Metrics
 
 This document explains how the rewards for validator are evaluated and displayed on the [Aptos Validator Status](https://explorer.aptoslabs.com/validators/all?network=mainnet) page.
 

--- a/docs/nodes/measure/node-health-checker-faq.md
+++ b/docs/nodes/measure/node-health-checker-faq.md
@@ -1,9 +1,6 @@
 ---
 title: "Node Health Checker FAQ"
-slug: "node-health-checker-faq"
 ---
-
-# Node Health Checker FAQ
 
 The Aptos Node Health Checker (NHC) service can be used to check the health of your node(s). See [Node Health Checker](./node-health-checker.md) for full documentation on the NHC.
 

--- a/docs/nodes/measure/node-health-checker.md
+++ b/docs/nodes/measure/node-health-checker.md
@@ -1,9 +1,6 @@
 ---
 title: "Node Health Checker"
-slug: "node-health-checker"
 ---
-
-# Node Health Checker
 
 The Aptos Node Health Checker (NHC) service can be used to check the health of the following Aptos node types:
 

--- a/docs/nodes/measure/node-inspection-service.md
+++ b/docs/nodes/measure/node-inspection-service.md
@@ -1,9 +1,6 @@
 ---
 title: "Node Inspection Service"
-slug: "node-inspection-service"
 ---
-
-# Node Inspection Service
 
 Aptos nodes collect metrics and system information while running. These metrics provide a way to track,
 monitor and inspect the health and performance of the node dynamically, at runtime. Node metrics and system

--- a/docs/nodes/networks.md
+++ b/docs/nodes/networks.md
@@ -1,6 +1,5 @@
 ---
 title: "Networks"
-slug: "networks"
 hide_table_of_contents: true
 ---
 

--- a/docs/nodes/node-files-all-networks/node-files.md
+++ b/docs/nodes/node-files-all-networks/node-files.md
@@ -1,9 +1,6 @@
 ---
 title: "Node Files For Mainnet"
-slug: "node-files"
 ---
-
-# Node Files For Mainnet
 
 When you are deploying an Aptos node in the **mainnet**, you will need to download the files listed on this page.
 

--- a/docs/nodes/nodes-landing.md
+++ b/docs/nodes/nodes-landing.md
@@ -1,10 +1,7 @@
 ---
 title: "Learn about Nodes"
-slug: "nodes-landing"
 hide_table_of_contents: true
 ---
-
-# Learn about Nodes
 
 The Aptos network consists of three node types: validator node, validator fullnode and public fullnode. To
 participate in consensus, you are required to run both a validator node and a validator fullnode, and stake.

--- a/docs/nodes/validator-node/operator/delegation-pool-operations.md
+++ b/docs/nodes/validator-node/operator/delegation-pool-operations.md
@@ -1,9 +1,6 @@
 ---
 title: "Delegation Pool Operations"
-slug: "delegation-pool-operations"
 ---
-
-# Delegation Pool Operations
 
 > Beta: This documentation is in experimental, beta mode. Supply feedback by [requesting document changes](../../../community/site-updates.md#request-docs-changes). See also the related [Staking Pool Operations](./staking-pool-operations.md) instructions.
 

--- a/docs/nodes/validator-node/operator/node-liveness-criteria.md
+++ b/docs/nodes/validator-node/operator/node-liveness-criteria.md
@@ -1,9 +1,6 @@
 ---
 title: "Node Liveness Criteria"
-slug: "node-liveness-criteria"
 ---
-
-# Node Liveness Criteria
 
 When you participate in the Aptos network, your validator node and the validator fullnode must pass liveness checks within 24 hours of being selected to participate in the network, and at a regular cadence onwards. This is required to ensure that your nodes contribute to the health of the overall network.
 

--- a/docs/nodes/validator-node/operator/node-requirements.md
+++ b/docs/nodes/validator-node/operator/node-requirements.md
@@ -1,9 +1,6 @@
 ---
 title: "Node Requirements"
-slug: "node-requirements"
 ---
-
-# Node Requirements
 
 To make your validator node and validator fullnode deployment hassle-free, make sure you have the resources specified in this document.
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -1,6 +1,5 @@
 ---
 title: "Aptos Error Codes"
-slug: "error-codes"
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,6 +1,5 @@
 ---
 title: "Aptos Glossary"
-slug: "glossary"
 ---
 
 # Aptos Glossary

--- a/docs/reference/telemetry.md
+++ b/docs/reference/telemetry.md
@@ -1,6 +1,5 @@
 ---
 title: "Telemetry"
-slug: "telemetry"
 ---
 
 When you operate a node on an Aptos network, your node can be set to send telemetry data to Aptos Labs. You can disable telemetry at any point. If telemetry remains enabled, Aptos node binary will send telemetry data in the background.

--- a/docs/sdks/python-sdk.md
+++ b/docs/sdks/python-sdk.md
@@ -1,6 +1,5 @@
 ---
 title: "Python SDK"
-slug: "python-sdk"
 ---
 
 # Aptos Python SDK

--- a/docs/sdks/rust-sdk.md
+++ b/docs/sdks/rust-sdk.md
@@ -1,6 +1,5 @@
 ---
 title: "Rust SDK"
-slug: "rust-sdk"
 ---
 
 # Aptos Rust SDK

--- a/docs/sdks/unity-sdk.md
+++ b/docs/sdks/unity-sdk.md
@@ -1,6 +1,5 @@
 ---
 title: "Unity SDK"
-slug: "unity-sdk"
 ---
 
 # Aptos Unity SDK

--- a/docs/standards/multisig-managed-fungible-asset.md
+++ b/docs/standards/multisig-managed-fungible-asset.md
@@ -1,6 +1,5 @@
 ---
 title: "Manage Fungible Assets with Aptos Multisig Account"
-slug: "multisig-managed-fungible-assets"
 ---
 
 # Manage Fungible Assets with Aptos Framework Multisig Account

--- a/docs/tutorials/programmatic-upgradeable-module.md
+++ b/docs/tutorials/programmatic-upgradeable-module.md
@@ -1,6 +1,5 @@
 ---
 title: "Programmatic Upgradeable Module"
-slug: "programmatic-upgradeable-module"
 ---
 
 # Programmatic Upgradeable Module
@@ -70,8 +69,8 @@ resource_account = "0xf48832b9e57bccc6943ec567f95b1cddab880d2e979706bc988d3e8f44
    To do this, we run the command:
 
 - `aptos move create-resource-account-and-publish-package --address-name <your-address> --seed <seed>`
-   1. Replace `<your-address>` with your account address.
-   2. Replace `<seed>` with a seed that only you know. This is used as a custom input to generate the resource account address.
+  1.  Replace `<your-address>` with your account address.
+  2.  Replace `<seed>` with a seed that only you know. This is used as a custom input to generate the resource account address.
 
 When running this command, this will **FIRST calculate** your resource account address.
 A prompt below will show:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,8 +36,7 @@ const config = {
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
           sidebarCollapsible: false,
-          editUrl:
-            "https://github.com/aptos-labs/developer-docs/edit/main",
+          editUrl: "https://github.com/aptos-labs/developer-docs/edit/main",
           remarkPlugins: [codeInjector, math],
           path: "docs",
           rehypePlugins: [katex],

--- a/scripts/additional_dict.txt
+++ b/scripts/additional_dict.txt
@@ -4,6 +4,7 @@ ACK
 AIP
 AIPs
 AIT
+AllFunctions
 AN
 ANSClient
 ANs
@@ -85,6 +86,7 @@ Dev
 DevEx
 Devnet
 Diffie
+dir
 DoS
 DocGen
 Duif
@@ -334,6 +336,7 @@ VR
 ValidateTransaction
 Validator
 Validators
+VerifiedFunction
 Vm
 WAV
 WELLDONE
@@ -533,6 +536,7 @@ multinode
 multisig
 multisignature
 multisigner
+mut
 namespace
 namespaces
 natively
@@ -573,6 +577,7 @@ prebuilt
 precompiled
 preconfigure
 presale
+proc
 profiler
 programmability
 programmatically
@@ -678,6 +683,7 @@ validators
 verifications
 verifier
 visibilities
+vc
 vm
 walkthrough
 wayness

--- a/sidebars.js
+++ b/sidebars.js
@@ -463,7 +463,6 @@ const sidebars = {
           collapsible: true,
           collapsed: true,
           items: [
-            "guides/sponsored-transactions",
             "guides/local-development-network",
             "nodes/local-testnet/run-a-local-testnet",
             "guides/running-a-local-multi-node-network",

--- a/static/move-examples/move-tutorial/README.md
+++ b/static/move-examples/move-tutorial/README.md
@@ -1,6 +1,5 @@
 ---
 title: "Aptos Move Tutorial"
-slug: "move-tutorial"
 ---
 
 # Move Tutorial


### PR DESCRIPTION
### Description
If there is a `#` (h1) in the doc, it will not automatically inject a title based on the value in the front matter. I fix this by switching all the `#` I see later in the docs to `##` (which looks the same besides some spacing changes, which I think are better anyway).

While I'm here I remove redundant slugs and fix a couple of other issues (e.g. with entries appearing in the wrong spot in the sidebar, missing spellcheck entries).

### Checklist

- [x] Do all Lints pass?
- [x] Have you ran `pnpm spellcheck`?
- [x] Have you ran `pnpm fmt`?
- [x] Have you ran `pnpm lint`?
