### PR TITLE
Dynamic footer copyright year & Telegram url fix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -144,7 +144,7 @@ We are excited that you are here, and we look forward to getting to know you. We
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/aptos)
 - [Forum](https://forum.aptoslabs.com/)
 - [Medium](https://medium.com/aptoslabs)
-- [Telegram](https://t.me/aptos_official)
+- [Telegram](https://t.me/AptosTG)
 - [Twitter](https://twitter.com/Aptos_Network)
 
 ## Community projects on Aptos

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -268,7 +268,7 @@ const config = {
                     <svg width="100%" height="100%" version="1.2" baseProfile="tiny" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 112 112" overflow="visible" xml:space="preserve"><path fill="currentColor" d="M86.6 37.4h-9.9c-1.1 0-2.2-.5-3-1.3l-4-4.5c-1.2-1.3-3.1-1.4-4.5-.3l-.3.3-3.4 3.9c-1.1 1.3-2.8 2-4.5 2H2.9C1.4 41.9.4 46.6 0 51.3h51.2c.9 0 1.8-.4 2.4-1l4.8-5c.6-.6 1.4-1 2.3-1h.2c.9 0 1.8.4 2.4 1.1l4 4.5c.8.9 1.9 1.4 3 1.4H112c-.4-4.7-1.4-9.4-2.9-13.8H86.6zM53.8 65l-4-4.5c-1.2-1.3-3.1-1.4-4.5-.3l-.3.3-3.5 3.9c-1.1 1.3-2.7 2-4.4 2H.8c.9 4.8 2.5 9.5 4.6 14h25.5c.9 0 1.7-.4 2.4-1l4.8-5c.6-.6 1.4-1 2.3-1h.2c.9 0 1.8.4 2.4 1.1l4 4.5c.8.9 1.9 1.4 3 1.4h56.6c2.1-4.4 3.7-9.1 4.6-14H56.8c-1.2 0-2.3-.5-3-1.4zm19.6-43.6 4.8-5c.6-.6 1.4-1 2.3-1h.2c.9 0 1.8.4 2.4 1l4 4.5c.8.9 1.9 1.3 3 1.3h10.8c-18.8-24.8-54.1-29.7-79-11-4.1 3.1-7.8 6.8-11 11H71c1 .2 1.8-.2 2.4-.8zM34.7 94.2c-1.2 0-2.3-.5-3-1.3l-4-4.5c-1.2-1.3-3.2-1.4-4.5-.2l-.2.2-3.5 3.9c-1.1 1.3-2.7 2-4.4 2h-.2C36 116.9 71.7 118 94.4 96.7c.9-.8 1.7-1.7 2.6-2.6H34.7z"/></svg>
                   </a>
                   <div class="copyright">
-                    <p class="copyright-text">© 2022 Aptos Foundation</p>
+                    <p class="copyright-text">© ${new Date().getFullYear()} Aptos Foundation</p>
                     <div class="copyright-links">
                       <a href="https://aptosfoundation.org/privacy" target="_blank">Privacy</a>
                       <a href="https://aptosfoundation.org/terms" target="_blank">Terms</a></div>


### PR DESCRIPTION
### Description

- Fixes copyright year from static `© 2022` to utilize `Date().getFullYear` 
<img width="261" alt="image" src="https://github.com/aptos-labs/developer-docs/assets/98909677/fc51b34a-03ac-424c-9fdc-e35dd70d517f">
<img width="282" alt="image" src="https://github.com/aptos-labs/developer-docs/assets/98909677/b47a9c78-6303-46de-9c10-75a914799b28">

- Update Telegram URL to official Aptos TG channel

### Checklist

- [x] Do all Lints pass?
- [x] Have you ran `pnpm spellcheck`?
- [x] Have you ran `pnpm fmt`?
- [x] Have you ran `pnpm lint`?
