### PR TITLE
Minor change to summary to reflect addition of for loops.

### DIFF
--- a/docs/move/book/SUMMARY.md
+++ b/docs/move/book/SUMMARY.md
@@ -23,7 +23,7 @@
 - [Equality](equality.md)
 - [Abort and Assert](abort-and-assert.md)
 - [Conditionals](conditionals.md)
-- [While and Loop](loops.md)
+- [While, For, and Loop](loops.md)
 - [Functions](functions.md)
 - [Structs and Resources](structs-and-resources.md)
 - [Constants](constants.md)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,7 +12,7 @@ const { ProvidePlugin } = require("webpack");
 const math = require("remark-math");
 const katex = require("rehype-katex");
 
-const postcssPreset = require('postcss-preset-env');
+const postcssPreset = require("postcss-preset-env");
 
 /** @type {import("@docusaurus/types").Config} */
 const config = {
@@ -441,12 +441,12 @@ const config = {
       },
     }),
     () => ({
-      name: 'new-css-syntax',
+      name: "new-css-syntax",
       configurePostCss(options) {
-          options.plugins.push(postcssPreset); // allow newest CSS syntax
-          return options;
+        options.plugins.push(postcssPreset); // allow newest CSS syntax
+        return options;
       },
-  }),
+    }),
   ],
 };
 


### PR DESCRIPTION
### Description

- The move book summary page was missing `for` loops. Added it.
- `pnpm fmt` on main suggested a change. Adding the change.

### Checklist

- [x] Do all Lints pass?
- [x] Have you ran `pnpm spellcheck`?
- [x] Have you ran `pnpm fmt`?
- [x] Have you ran `pnpm lint`?
