### PR TITLE
add remark mermaid to dynamic load markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.0",
     "remark-math": "^6.0.0",
+    "remark-mermaid-plugin": "^1.0.2",
     "remark-stringify": "^11.0.0",
     "search-insights": "^2.13.0",
     "shelljs": "^0.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ dependencies:
   remark-math:
     specifier: ^6.0.0
     version: 6.0.0
+  remark-mermaid-plugin:
+    specifier: ^1.0.2
+    version: 1.0.2
   remark-stringify:
     specifier: ^11.0.0
     version: 11.0.0
@@ -7248,6 +7251,13 @@ packages:
       lodash-es: 4.17.21
     dev: false
 
+  /dagre-d3-es@7.0.9:
+    resolution: {integrity: sha512-rYR4QfVmy+sR44IBDvVtcAmOReGBvRCWDpO2QjYwqgh9yijw6eSHBqaPG/LIOEy7aBsniLvtMW6pg19qJhq60w==}
+    dependencies:
+      d3: 7.8.5
+      lodash-es: 4.17.21
+    dev: false
+
   /data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -7477,6 +7487,10 @@ packages:
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
+    dev: false
+
+  /dompurify@2.4.3:
+    resolution: {integrity: sha512-q6QaLcakcRjebxjg8/+NP+h0rPfatOgOzc46Fst9VAA3jF2ApfKBNKMzdP4DYTqtUMXSCd5pRS/8Po/OmoCHZQ==}
     dev: false
 
   /dompurify@3.0.8:
@@ -9925,6 +9939,11 @@ packages:
     dependencies:
       '@types/mdast': 4.0.3
 
+  /mdast@3.0.0:
+    resolution: {integrity: sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g==}
+    deprecated: '`mdast` was renamed to `remark`'
+    dev: false
+
   /mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
     dev: false
@@ -9982,6 +10001,27 @@ packages:
       web-worker: 1.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /mermaid@9.4.3:
+    resolution: {integrity: sha512-TLkQEtqhRSuEHSE34lh5bCa94KATCyluAXmFnNI2PRZwOpXFeqiJWwZl+d2CcemE1RS6QbbueSSq9QIg8Uxcyw==}
+    dependencies:
+      '@braintree/sanitize-url': 6.0.4
+      cytoscape: 3.28.1
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.28.1)
+      cytoscape-fcose: 2.2.0(cytoscape@3.28.1)
+      d3: 7.8.5
+      dagre-d3-es: 7.0.9
+      dayjs: 1.11.10
+      dompurify: 2.4.3
+      elkjs: 0.8.2
+      khroma: 2.1.0
+      lodash-es: 4.17.21
+      non-layered-tidy-tree-layout: 2.0.2
+      stylis: 4.3.1
+      ts-dedent: 2.2.0
+      uuid: 9.0.1
+      web-worker: 1.3.0
     dev: false
 
   /methods@1.1.2:
@@ -12659,6 +12699,15 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /remark-mermaid-plugin@1.0.2:
+    resolution: {integrity: sha512-qfN0pxHESUgqfg8WPIxmfyb5BQ8KCniZ9NxwXbM85Ba4RkjvuJnO13PD+JUoz+PGJwyWO0Hrd13g7WzmuwtF6w==}
+    dependencies:
+      mdast: 3.0.0
+      mermaid: 9.4.3
+      unified: 10.1.2
+      unist-util-visit: 4.1.2
+    dev: false
+
   /remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
     dependencies:
@@ -13596,6 +13645,18 @@ packages:
   /unicode-property-aliases-ecmascript@2.1.0:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
+    dev: false
+
+  /unified@10.1.2:
+    resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
+    dependencies:
+      '@types/unist': 2.0.10
+      bail: 2.0.2
+      extend: 3.0.2
+      is-buffer: 2.0.5
+      is-plain-obj: 4.1.0
+      trough: 2.1.0
+      vfile: 5.3.7
     dev: false
 
   /unified@11.0.4:

--- a/src/components/MoveReference/index.tsx
+++ b/src/components/MoveReference/index.tsx
@@ -3,6 +3,7 @@ import BrowserOnly from "@docusaurus/BrowserOnly";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
+import remarkMermaid from "remark-mermaid-plugin";
 import {
   Select,
   Label,
@@ -198,7 +199,7 @@ const Content = ({ branch, page }: ContentProps) => {
         <ReactMarkdown
           children={content}
           rehypePlugins={[rehypeRaw]}
-          remarkPlugins={[remarkGfm]}
+          remarkPlugins={[remarkGfm, remarkMermaid as any]}
           remarkRehypeOptions={{ allowDangerousHtml: true }}
         />
       ) : page ? (


### PR DESCRIPTION
### Description
When getting the raw markdown from http requests and parsing it into HTML with ReactMarkdown, it doesn't use the Docusaurus v2 default markdown engine. 

ref: #40 

results:
https://deploy-preview-96--aptos-developer-docs.netlify.app/reference/move/?branch=mainnet&page=aptos-framework/doc/storage_gas.md#function-dependencies

### Checklist

- [x] Do all Lints pass?
- [x] Have you ran `pnpm spellcheck`?
- [x] Have you ran `pnpm fmt`?
- [x] Have you ran `pnpm lint`?
