### PR TITLE
Rust Secure Coding Guidelines

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -43,7 +43,7 @@ Help organize events, develop content and more for the ecosystem by joining the 
 We at Aptos love direct contributions in the form of [pull requests](https://github.com/aptos-labs/aptos-core/pulls). Help us make small fixes to code. Follow our coding conventions for:
 
 - [Move](../move/book/coding-conventions.md)
-- [Rust](./rust-coding-guidelines.md)
+- [Rust](./rust-coding-guidelines/rust-coding-guidelines.md)
 
 ## Update the documentation
 

--- a/docs/community/rust-coding-guidelines/rust-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-coding-guidelines.md
@@ -1,6 +1,6 @@
 ---
 id: rust-coding-guidelines
-title: Coding Guidelines
+title: Coding Guidelines for Aptos Core
 ---
 
 This document describes the coding guidelines for the [Aptos Core](https://github.com/aptos-labs/aptos-core) Rust codebase. For the Move language, see the [Move Coding Conventions](../../move/book/coding-conventions.md).

--- a/docs/community/rust-coding-guidelines/rust-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-coding-guidelines.md
@@ -1,9 +1,9 @@
 ---
 id: rust-coding-guidelines
-title: Rust Coding Guidelines
+title: Coding Guidelines
 ---
 
-This document describes the coding guidelines for the [Aptos Core](https://github.com/aptos-labs/aptos-core) Rust codebase. For the Move language, see the [Move Coding Conventions](../move/book/coding-conventions.md).
+This document describes the coding guidelines for the [Aptos Core](https://github.com/aptos-labs/aptos-core) Rust codebase. For the Move language, see the [Move Coding Conventions](../../move/book/coding-conventions.md).
 
 ## Code formatting
 

--- a/docs/community/rust-coding-guidelines/rust-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-coding-guidelines.md
@@ -288,10 +288,6 @@ References:
 - [An introduction to property-based testing](https://fsharpforfunandprofit.com/posts/property-based-testing/)
 - [Choosing properties for property-based testing](https://fsharpforfunandprofit.com/posts/property-based-testing-2/)
 
-_Fuzzing_
-
-Aptos contains harnesses for fuzzing crash-prone code like deserializers, using [`libFuzzer`](https://llvm.org/docs/LibFuzzer.html) through [`cargo fuzz`](https://rust-fuzz.github.io/book/cargo-fuzz.html). For more examples, see the `testsuite/aptos_fuzzer` directory.
-
 ### Conditional compilation of tests
 
 Aptos [conditionally

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -124,7 +124,7 @@ By utilizing these primitives, Rust programs can manage shared resources among m
 
 Certain data structures, like HashMap and HashSet, do not guarantee a deterministic order for the elements stored within them. This lack of order can lead to problems in operations that require processing elements in a consistent sequence across multiple executions. Below is a list of deterministic data structures available in Rust. Please note, this list may not be exhaustive:
 
-- **BTreeMap:** It maintains its elements in sorted order by their keys.
+- **BTreeMap:** maintains its elements in sorted order by their keys.
 - **BinaryHeap:** It maintains its elements in a heap order, which is a complete binary tree where each parent node is less than or equal to its child nodes.
 - **Vec**: It maintains its elements in the order in which they were inserted. ⚠️
 - **LinkedList:** It maintains its elements in the order in which they were inserted. ⚠️

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -59,7 +59,7 @@ Document safety invariants and security considerations in code, especially for p
 Assess and monitor the quality and maintenance of crates that are being introduced to the codebase, employing tools like `cargo-outdated` and `cargo-audit` for version management and vulnerability checking [[audit lib]](https://anssi-fr.github.io/rust-guide/03_libraries.html#libraries).
 
 - Aptos utilizes **[Dependabot](https://github.com/dependabot)** to continuously monitor libraries. Our policy requires mandatory updates for critical and high-vulnerabilities, or upon impact evaluation given the context for medium and lower.
-- When vetting a new library, it's advisable to utilize deps.dev for evaluation. This site provides an OpenSSF scorecard containing essential information. As a guideline, libraries with an OpenSSF score of 7 or higher are typically safe to import. However, those scoring **below 7** must undergo discussion prior to importation.
+- We recommend leveraging [deps.dev](https://deps.dev) to evaluate new third party crates. This site provides an OpenSSF stcorecard containing essential information. As a guideline, libraries with a score of 7 or higher are typically safe to import. However, those scoring **below 7** must be flagged during the PR and require a specific justification.
 
 ### Minimize Use of Feature Flags
 

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -1,0 +1,220 @@
+---
+id: rust-secure-coding-guidelines
+title: Secure Coding
+---
+
+These Rust Secure Coding Guidelines are essential for anyone contributing to Aptos, reflecting our security-first approach. As Aptos is built with a primary focus on security, these guidelines, derived and adapted from ANSSI's Secure Rust Guidelines, are integral to maintaining the high standards of safety and robustness in aptos-core. Aptos contributors are encouraged to thoroughly understand and apply these principles in their work.
+
+## Development Environment
+
+### Rustup
+ Utilize Rustup for managing Rust toolchains. However, keep in mind that, from a security perspective, Rustup performs all downloads over HTTPS, but it does not yet validate signatures of downloads. Security is shifted to [create.io](http://create.io) and GitHub repository hosting the code [[rustup]](https://anssi-fr.github.io/rust-guide/02_devenv.html#rustup).
+
+### Stable Toolchain
+ Development of a secure application must be done using a fully stable toolchain, for limiting potential compiler, runtime, or tool bugs [[toolchains considerations]](https://anssi-fr.github.io/rust-guide/02_devenv.html#stable-nightly-and-beta-toolchains).
+
+### Cargo
+Utilize Cargo for project management without overriding variables like `debug-assertions` and `overflow-checks` [[cargo]](https://anssi-fr.github.io/rust-guide/02_devenv.html#cargo).
+  - **`debug-assertions`**: This variable controls whether debug assertions are enabled. Debug assertions are checks that are only present in debug builds. They are used to catching bugs during development by validating assumptions made in the code.
+  - **`overflow-checks`**: This variable determines whether arithmetic overflow checks are performed. In Rust, when overflow checks are enabled (which is the default in debug mode), an integer operation that overflows will cause a panic in debug builds, preventing potential security vulnerabilities like buffer overflows.
+
+### Linters and Formatters
+ Regularly use tools like Clippy and Rustfmt for identifying potential issues and maintaining code style [[clippy]](https://anssi-fr.github.io/rust-guide/02_devenv.html#clippy) [[rustfmt]](https://anssi-fr.github.io/rust-guide/02_devenv.html#rustfmt). Aptos **enforces** Clippy during automated testing with additional rules, so ensure to run it locally to prevent CI/CD failures.
+
+Clippy with Aptos-specific configuration can be run locally via `cargo xclippy` or using rust-analyser in your preferred IDE following these [instructions](https://rust-analyzer.github.io/manual.html#clippy). Aptos uses directives in files and a per-directory configuration to turn on or off checks.
+
+### Rustfix
+ Apply `rustfix` for compiler warnings and edition transitions, but verify the automatic fixes to ensure that the recommendations match the purpose of the code [[rustfix]](https://anssi-fr.github.io/rust-guide/02_devenv.html#rustfix).
+
+### Documentation
+Document safety invariants and security considerations in code, especially for public and `unsafe` functions.
+    
+  ```rust
+    foo(
+        // SAFETY:
+        // This is a valid safety comment
+        unsafe { *x }
+    )
+    ```
+    
+    ```rust
+    use std::ptr::NonNull;
+    let a = &mut 42;
+    
+    // SAFETY: references are guaranteed to be non-null.
+    let ptr = unsafe { NonNull::new_unchecked(a) };
+  ```
+
+## Libraries
+
+### Crate Quality and Security
+Assess and monitor the quality and maintenance of used crates, employing tools like `cargo-outdated` and `cargo-audit` for version management and vulnerability checking [[audit lib]](https://anssi-fr.github.io/rust-guide/03_libraries.html#libraries).
+  - Aptos utilizes **[Dependabot](https://github.com/dependabot)** to continuously monitor libraries. Our policy requires mandatory updates for critical and high-vulnerabilities, or upon impact evaluation given the context for medium and lower.
+  - When vetting a new library, it's advisable to utilize deps.dev for evaluation. This site provides an OpenSSF scorecard containing essential information. As a guideline, libraries with an OpenSSF score of 7 or higher are typically safe to import. However, those scoring **below 7** must undergo discussion prior to importation.
+
+### Minimize Use of Feature Flags
+ As a general practice, avoid using feature flags in your crates unless absolutely necessary. Feature flags can introduce complexity and unexpected behaviours, making the codebase harder to audit for security vulnerabilities.
+
+### Understanding Feature Unification
+ Be aware of Cargo's feature unification process. When multiple dependencies require the same crate with different feature flags, Cargo unifies these into a single configuration. This unification can inadvertently enable features that might not be desirable or secure for the project [[Rustbook: features unification]](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification) [[Rustbook: feature resolver]](https://doc.rust-lang.org/cargo/reference/features.html#feature-resolver-version-2).
+
+## Language Generalities
+
+### Unsafe Code
+ Never use `unsafe` blocks unless as a last resort. Justify their use in a comment, detailing how the code is effectively safe to deploy [[unsafe code]](https://anssi-fr.github.io/rust-guide/04_language.html#unsafe-code).
+
+### Integer Overflows
+ Refer to [coding-guidelines](./rust-coding-guidelines.md#integer-arithmetic).
+
+### Error Handling
+ Use `Result<T, E>` and `Option<T>` for error handling instead of *unwrapping* or *expecting*, to avoid panics [[error handling]](https://anssi-fr.github.io/rust-guide/04_language.html#error-handling) [[panic]](https://anssi-fr.github.io/rust-guide/04_language.html#panics) [[coding-style]](rust-coding-guidelines.md/#error-handling).
+
+### Assertions
+ Prefer using `Result` and context-rich error handling over Rust's `assert!`, `assert_eq!`, and `assert_ne!` macros for enforcing invariants, reserving assertions for development and unrecoverable error scenarios.
+
+## Types Systems and Data Structures
+
+### Drop Trait
+ Implement the `Drop` trait selectively and ensure it doesn't cause panics [[drop trait the destructor]](https://anssi-fr.github.io/rust-guide/06_typesystem.html#drop-trait-the-destructor).
+  - Implement the Drop trait selectively, only when necessary for specific destructor logic. It's mainly used for managing external resources or memory in structures like Box or Rc, often involving unsafe code and security-critical operations.
+  - In a Rust secure development, the implementation of the `std::ops::Drop` trait
+    must not panic.
+  - Do not rely on `Drop` trait in security material treatment after the use, use [zeroize](https://docs.rs/zeroize/latest/zeroize/#) to explicit destroy security material, e.g. private keys.
+
+### Send and Sync Traits
+ Be cautious with manual implementations of `Send` and `Sync` traits [[Rustbook: typesystem]](https://anssi-fr.github.io/rust-guide/06_typesystem.html#send-and-sync-traits) [[Rustbook: send and sync]](https://doc.rust-lang.org/nomicon/send-and-sync.html).
+Both traits are *unsafe traits*, i.e., the Rust compiler does not verify in any way that they are implemented correctly. The danger is real: an incorrect implementation may lead to **undefined behavior**.
+
+In the majority of scenarios, manual implementation is unnecessary. In Rust, nearly all primitive types intrinsically implement Send and Sync traits, and for a significant proportion of compound types, the Rust compiler automatically derives these implementations.
+
+### Comparison Traits
+ Ensure the implementation of standard comparison traits respects documented invariants [[comparison traits partialeq eq partialord ord]](https://anssi-fr.github.io/rust-guide/06_typesystem.html#comparison-traits-partialeq-eq-partialord-ord).
+> The ANSSI resource extensively covers the matter, an example in [Appendix](#implementation-of-comparison-traits) is provided as a really basic demonstration of implementation.
+
+### Enums
+ Prefer enums for state management to prevent invalid state representation.
+
+### Concurrency Safe Primitives
+Make use of Rust’s concurrency primitives like `Arc`, `Mutex`, and `RwLock` to manage shared state [[Rustbook: concurrency]](https://doc.rust-lang.org/book/ch16-00-concurrency.html).
+By utilizing these primitives, Rust programs can manage shared resources among multiple threads safely and efficiently, adhering to Rust's goals of enabling fearless concurrency and memory safety. This is critical in multithread programs because mistakes in concurrency can be very costly, both for the system's stability and security.
+
+### Data Structures with Deterministic Internal Order
+Certain data structures, like HashMap and HashSet, do not guarantee a deterministic order for the elements stored within them. This lack of order can lead to problems in operations that require processing elements in a consistent sequence across multiple executions. Below is a list of deterministic data structures available in Rust. Please note, this list may not be exhaustive:
+  - **BTreeMap:** It maintains its elements in sorted order by their keys.
+  - **BinaryHeap:** It maintains its elements in a heap order, which is a complete binary tree where each parent node is less than or equal to its child nodes.
+  - **VEC**: It maintains its elements in the order in which they were inserted. ⚠️
+  - **LinkedList:** It maintains its elements in the order in which they were inserted. ⚠️
+  - **VecDeque:** It maintains its elements in the order in which they were inserted. ⚠️
+
+
+## Cryptography
+
+### Talk to a cryptographer
+ If you’re using cryptography in your code and you are **not** a cryptographer, you don’t know what you don’t know (*e.g.,* small subgroup attacks, malleability attacks, domain-separation attacks, collision resistance versus one-wayness, safe key reuse, correctly using randomness, nonce reuse, CCA security, CPA security, etc). So ask for help from a cryptographer in our team (Alin, Benny, Michael, Rex).
+
+### No Custom Cryptographic Algorithm
+Use exclusively the cryptographic primitives exposed by the `aptos-crypto` crate. This does **not** mean you will be able to use them safely, so [talk to a cryptographer](#talk-to-a-cryptographer)!
+
+### Cryptographic Material Management
+Adhere strictly to established protocols for generating, storing, and managing cryptographic keys. This includes using secure random sources for key generation, ensuring keys are stored in protected environments, and implementing robust management practices to handle key lifecycle events like rotation and revocation [[Key Management Cheat Sheet]](https://cheatsheetseries.owasp.org/cheatsheets/Key_Management_Cheat_Sheet.html).
+
+### Zeroing Sensitive Data
+Use [zeroize](https://docs.rs/zeroize/latest/zeroize/#) for zeroing memory containing sensitive data.
+
+## Misc
+### Forget and Memory Leaks
+Avoid using `std::mem::forget` in secure development, or any other function that leaks the memory [[forget and memory leaks]](https://anssi-fr.github.io/rust-guide/05_memory.html#forget-and-memory-leaks).
+> Reference cycles can also cause memory leakage [[Rustbook: leak]](https://doc.rust-lang.org/book/ch15-06-reference-cycles.html?highlight=leak#reference-cycles-can-leak-memory).
+
+Most memory leaks result in general product reliability problems. If an attacker can intentionally trigger a memory leak, the attacker might be able to launch a denial-of-service attack (by crashing or hanging the program).
+
+## Appendix
+
+#### Implementation of Comparison Traits
+    
+```rust
+    use std::cmp::Ordering;
+    
+    /// A struct representing a 2D point.
+    #[derive(Debug)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+    
+    /// Implementing the PartialEq trait for Point.
+    /// 
+    /// This implementation respects the documented invariant that for any points a and b,
+    /// a == b if and only if both their x and y coordinates are equal.
+    impl PartialEq for Point {
+        fn eq(&self, other: &Self) -> bool {
+            // Points are considered equal if their x and y coordinates are the same.
+            self.x == other.x && self.y == other.y
+        }
+    }
+    
+    /// Implementing the PartialOrd trait for Point.
+    /// 
+    /// The documented invariant here is that the points are ordered primarily by their x-coordinate,
+    /// and then by their y-coordinate. This means that for any points a and b,
+    /// a < b if a.x < b.x or if a.x == b.x and a.y < b.y.
+    impl PartialOrd for Point {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            match (self.x.cmp(&other.x), self.y.cmp(&other.y)) {
+                // If both coordinates are equal, the points are equal.
+                (Ordering::Equal, Ordering::Equal) => Some(Ordering::Equal),
+                // If x coordinates are equal, compare y coordinates.
+                (Ordering::Equal, ord) => Some(ord),
+                // Otherwise, order by x coordinate.
+                (ord, _) => Some(ord),
+            }
+        }
+    }
+    
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+    
+        #[test]
+        fn test_equality() {
+            let point1 = Point { x: 1, y: 2 };
+            let point2 = Point { x: 1, y: 2 };
+            let point3 = Point { x: 2, y: 3 };
+    
+            assert_eq!(point1, point2, "Points with same coordinates should be equal");
+            assert_ne!(point1, point3, "Points with different coordinates should not be equal");
+        }
+    
+        #[test]
+        fn test_inequality() {
+            let point1 = Point { x: 1, y: 2 };
+            let point2 = Point { x: 1, y: 3 };
+    
+            assert!(point1 != point2, "Points with different y coordinates should not be equal");
+        }
+    
+        #[test]
+        fn test_less_than() {
+            let point1 = Point { x: 1, y: 2 };
+            let point2 = Point { x: 1, y: 3 };
+            let point3 = Point { x: 2, y: 1 };
+    
+            assert!(point1 < point2, "Point1 should be less than Point2 based on y-coordinate");
+            assert!(point1 < point3, "Point1 should be less than Point3 based on x-coordinate");
+        }
+    
+        #[test]
+        fn test_greater_than() {
+            let point1 = Point { x: 1, y: 3 };
+            let point2 = Point { x: 1, y: 2 };
+            let point3 = Point { x: 2, y: 1 };
+    
+            assert!(point1 > point2, "Point1 should be greater than Point2 based on y-coordinate");
+            assert!(point3 > point2, "Point3 should be greater than Point2 based on x-coordinate");
+        }
+    }
+  ```
+
+# Conclusion
+
+These guidelines are a crucial element for anyone contributing to Aptos, reflecting our commitment to a security-first approach. By adhering to these guidelines, Aptos contributors play a vital role in maintaining the security and robustness of the Aptos network. As we work towards automating the enforcement of these standards, following these practices will help maintain and improve the overall integrity and resilience of the Aptos ecosystem. This ongoing effort ensures that Aptos continues to set a high bar for security and reliability.

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -66,13 +66,14 @@ Never use `unsafe` blocks unless as a last resort. Justify their use in a commen
       unsafe { *x }
   )
 ```
+
 ```rust
   use std::ptr::NonNull;
   let a = &mut 42;
 
   // SAFETY: references are guaranteed to be non-null.
   let ptr = unsafe { NonNull::new_unchecked(a) };
-````
+```
 
 ### Integer Overflows
 

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -126,7 +126,7 @@ Certain data structures, like HashMap and HashSet, do not guarantee a determinis
 
 - **BTreeMap:** It maintains its elements in sorted order by their keys.
 - **BinaryHeap:** It maintains its elements in a heap order, which is a complete binary tree where each parent node is less than or equal to its child nodes.
-- **VEC**: It maintains its elements in the order in which they were inserted. ⚠️
+- **Vec**: It maintains its elements in the order in which they were inserted. ⚠️
 - **LinkedList:** It maintains its elements in the order in which they were inserted. ⚠️
 - **VecDeque:** It maintains its elements in the order in which they were inserted. ⚠️
 

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -110,7 +110,7 @@ In the majority of scenarios, manual implementation is unnecessary. In Rust, nea
 Ensure the implementation of standard comparison traits respects documented invariants.
 In the context of implementing standard comparison traits (like Eq, PartialEq, Ord, PartialOrd in Rust), respecting documented invariants means that the implementation of these traits should adhere to the properties and expectations defined by those invariants. For instance, if an invariant states that an object's identity is determined by certain fields, comparisons (equality, greater than, less than, etc.) must only consider those fields and ignore others. This ensures consistency, predictability, and correctness in how objects are compared, sorted, or considered equal within the Aptos Core.
 
-> The ANSSI resource extensively covers the matter, an example in [Appendix](#implementation-of-comparison-traits) is provided as a really basic demonstration of implementation.
+> The ANSSI resource extensively covers the matter [Appendix](#Appendix).
 
 ### Enums
 
@@ -166,91 +166,6 @@ Aptos contains harnesses for fuzzing crash-prone code like deserializers, using 
 #### References
 
 - ANSSI's Secure Rust Guidelines: https://anssi-fr.github.io/rust-guide/
-
-#### Implementation of Comparison Traits
-
-```rust
-    use std::cmp::Ordering;
-
-    /// A struct representing a 2D point.
-    #[derive(Debug)]
-    struct Point {
-        x: i32,
-        y: i32,
-    }
-
-    /// Implementing the PartialEq trait for Point.
-    ///
-    /// This implementation respects the documented invariant that for any points a and b,
-    /// a == b if and only if both their x and y coordinates are equal.
-    impl PartialEq for Point {
-        fn eq(&self, other: &Self) -> bool {
-            // Points are considered equal if their x and y coordinates are the same.
-            self.x == other.x && self.y == other.y
-        }
-    }
-
-    /// Implementing the PartialOrd trait for Point.
-    ///
-    /// The documented invariant here is that the points are ordered primarily by their x-coordinate,
-    /// and then by their y-coordinate. This means that for any points a and b,
-    /// a < b if a.x < b.x or if a.x == b.x and a.y < b.y.
-    impl PartialOrd for Point {
-        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-            match (self.x.cmp(&other.x), self.y.cmp(&other.y)) {
-                // If both coordinates are equal, the points are equal.
-                (Ordering::Equal, Ordering::Equal) => Some(Ordering::Equal),
-                // If x coordinates are equal, compare y coordinates.
-                (Ordering::Equal, ord) => Some(ord),
-                // Otherwise, order by x coordinate.
-                (ord, _) => Some(ord),
-            }
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        #[test]
-        fn test_equality() {
-            let point1 = Point { x: 1, y: 2 };
-            let point2 = Point { x: 1, y: 2 };
-            let point3 = Point { x: 2, y: 3 };
-
-            assert_eq!(point1, point2, "Points with same coordinates should be equal");
-            assert_ne!(point1, point3, "Points with different coordinates should not be equal");
-        }
-
-        #[test]
-        fn test_inequality() {
-            let point1 = Point { x: 1, y: 2 };
-            let point2 = Point { x: 1, y: 3 };
-
-            assert!(point1 != point2, "Points with different y coordinates should not be equal");
-        }
-
-        #[test]
-        fn test_less_than() {
-            let point1 = Point { x: 1, y: 2 };
-            let point2 = Point { x: 1, y: 3 };
-            let point3 = Point { x: 2, y: 1 };
-
-            assert!(point1 < point2, "Point1 should be less than Point2 based on y-coordinate");
-            assert!(point1 < point3, "Point1 should be less than Point3 based on x-coordinate");
-        }
-
-        #[test]
-        fn test_greater_than() {
-            let point1 = Point { x: 1, y: 3 };
-            let point2 = Point { x: 1, y: 2 };
-            let point3 = Point { x: 2, y: 1 };
-
-            assert!(point1 > point2, "Point1 should be greater than Point2 based on y-coordinate");
-            assert!(point3 > point2, "Point3 should be greater than Point2 based on x-coordinate");
-        }
-    }
-```
 
 # Conclusion
 

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -8,122 +8,152 @@ These Rust Secure Coding Guidelines are essential for anyone contributing to Apt
 ## Development Environment
 
 ### Rustup
- Utilize Rustup for managing Rust toolchains. However, keep in mind that, from a security perspective, Rustup performs all downloads over HTTPS, but it does not yet validate signatures of downloads. Security is shifted to [create.io](http://create.io) and GitHub repository hosting the code [[rustup]](https://anssi-fr.github.io/rust-guide/02_devenv.html#rustup).
+
+Utilize Rustup for managing Rust toolchains. However, keep in mind that, from a security perspective, Rustup performs all downloads over HTTPS, but it does not yet validate signatures of downloads. Security is shifted to [create.io](http://create.io) and GitHub repository hosting the code [[rustup]](https://anssi-fr.github.io/rust-guide/02_devenv.html#rustup).
 
 ### Stable Toolchain
- Development of a secure application must be done using a fully stable toolchain, for limiting potential compiler, runtime, or tool bugs [[toolchains considerations]](https://anssi-fr.github.io/rust-guide/02_devenv.html#stable-nightly-and-beta-toolchains).
+
+Development of a secure application must be done using a fully stable toolchain, for limiting potential compiler, runtime, or tool bugs [[toolchains considerations]](https://anssi-fr.github.io/rust-guide/02_devenv.html#stable-nightly-and-beta-toolchains).
 
 ### Cargo
+
 Utilize Cargo for project management without overriding variables like `debug-assertions` and `overflow-checks` [[cargo]](https://anssi-fr.github.io/rust-guide/02_devenv.html#cargo).
-  - **`debug-assertions`**: This variable controls whether debug assertions are enabled. Debug assertions are checks that are only present in debug builds. They are used to catching bugs during development by validating assumptions made in the code.
-  - **`overflow-checks`**: This variable determines whether arithmetic overflow checks are performed. In Rust, when overflow checks are enabled (which is the default in debug mode), an integer operation that overflows will cause a panic in debug builds, preventing potential security vulnerabilities like buffer overflows.
+
+- **`debug-assertions`**: This variable controls whether debug assertions are enabled. Debug assertions are checks that are only present in debug builds. They are used to catching bugs during development by validating assumptions made in the code.
+- **`overflow-checks`**: This variable determines whether arithmetic overflow checks are performed. In Rust, when overflow checks are enabled (which is the default in debug mode), an integer operation that overflows will cause a panic in debug builds, preventing potential security vulnerabilities like buffer overflows.
 
 ### Linters and Formatters
- Regularly use tools like Clippy and Rustfmt for identifying potential issues and maintaining code style [[clippy]](https://anssi-fr.github.io/rust-guide/02_devenv.html#clippy) [[rustfmt]](https://anssi-fr.github.io/rust-guide/02_devenv.html#rustfmt). Aptos **enforces** Clippy during automated testing with additional rules, so ensure to run it locally to prevent CI/CD failures.
+
+Regularly use tools like Clippy and Rustfmt for identifying potential issues and maintaining code style [[clippy]](https://anssi-fr.github.io/rust-guide/02_devenv.html#clippy) [[rustfmt]](https://anssi-fr.github.io/rust-guide/02_devenv.html#rustfmt). Aptos **enforces** Clippy during automated testing with additional rules, so ensure to run it locally to prevent CI/CD failures.
 
 Clippy with Aptos-specific configuration can be run locally via `cargo xclippy` or using rust-analyser in your preferred IDE following these [instructions](https://rust-analyzer.github.io/manual.html#clippy). Aptos uses directives in files and a per-directory configuration to turn on or off checks.
 
 ### Rustfix
- Apply `rustfix` for compiler warnings and edition transitions, but verify the automatic fixes to ensure that the recommendations match the purpose of the code [[rustfix]](https://anssi-fr.github.io/rust-guide/02_devenv.html#rustfix).
+
+Apply `rustfix` for compiler warnings and edition transitions, but verify the automatic fixes to ensure that the recommendations match the purpose of the code [[rustfix]](https://anssi-fr.github.io/rust-guide/02_devenv.html#rustfix).
 
 ### Documentation
+
 Document safety invariants and security considerations in code, especially for public and `unsafe` functions.
-    
-  ```rust
-    foo(
-        // SAFETY:
-        // This is a valid safety comment
-        unsafe { *x }
-    )
-    ```
-    
-    ```rust
-    use std::ptr::NonNull;
-    let a = &mut 42;
-    
-    // SAFETY: references are guaranteed to be non-null.
-    let ptr = unsafe { NonNull::new_unchecked(a) };
+
+````rust
+  foo(
+      // SAFETY:
+      // This is a valid safety comment
+      unsafe { *x }
+  )
   ```
+
+  ```rust
+  use std::ptr::NonNull;
+  let a = &mut 42;
+
+  // SAFETY: references are guaranteed to be non-null.
+  let ptr = unsafe { NonNull::new_unchecked(a) };
+````
 
 ## Libraries
 
 ### Crate Quality and Security
+
 Assess and monitor the quality and maintenance of used crates, employing tools like `cargo-outdated` and `cargo-audit` for version management and vulnerability checking [[audit lib]](https://anssi-fr.github.io/rust-guide/03_libraries.html#libraries).
-  - Aptos utilizes **[Dependabot](https://github.com/dependabot)** to continuously monitor libraries. Our policy requires mandatory updates for critical and high-vulnerabilities, or upon impact evaluation given the context for medium and lower.
-  - When vetting a new library, it's advisable to utilize deps.dev for evaluation. This site provides an OpenSSF scorecard containing essential information. As a guideline, libraries with an OpenSSF score of 7 or higher are typically safe to import. However, those scoring **below 7** must undergo discussion prior to importation.
+
+- Aptos utilizes **[Dependabot](https://github.com/dependabot)** to continuously monitor libraries. Our policy requires mandatory updates for critical and high-vulnerabilities, or upon impact evaluation given the context for medium and lower.
+- When vetting a new library, it's advisable to utilize deps.dev for evaluation. This site provides an OpenSSF scorecard containing essential information. As a guideline, libraries with an OpenSSF score of 7 or higher are typically safe to import. However, those scoring **below 7** must undergo discussion prior to importation.
 
 ### Minimize Use of Feature Flags
- As a general practice, avoid using feature flags in your crates unless absolutely necessary. Feature flags can introduce complexity and unexpected behaviours, making the codebase harder to audit for security vulnerabilities.
+
+As a general practice, avoid using feature flags in your crates unless absolutely necessary. Feature flags can introduce complexity and unexpected behaviours, making the codebase harder to audit for security vulnerabilities.
 
 ### Understanding Feature Unification
- Be aware of Cargo's feature unification process. When multiple dependencies require the same crate with different feature flags, Cargo unifies these into a single configuration. This unification can inadvertently enable features that might not be desirable or secure for the project [[Rustbook: features unification]](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification) [[Rustbook: feature resolver]](https://doc.rust-lang.org/cargo/reference/features.html#feature-resolver-version-2).
+
+Be aware of Cargo's feature unification process. When multiple dependencies require the same crate with different feature flags, Cargo unifies these into a single configuration. This unification can inadvertently enable features that might not be desirable or secure for the project [[Rustbook: features unification]](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification) [[Rustbook: feature resolver]](https://doc.rust-lang.org/cargo/reference/features.html#feature-resolver-version-2).
 
 ## Language Generalities
 
 ### Unsafe Code
- Never use `unsafe` blocks unless as a last resort. Justify their use in a comment, detailing how the code is effectively safe to deploy [[unsafe code]](https://anssi-fr.github.io/rust-guide/04_language.html#unsafe-code).
+
+Never use `unsafe` blocks unless as a last resort. Justify their use in a comment, detailing how the code is effectively safe to deploy [[unsafe code]](https://anssi-fr.github.io/rust-guide/04_language.html#unsafe-code).
 
 ### Integer Overflows
- Refer to [coding-guidelines](./rust-coding-guidelines.md#integer-arithmetic).
+
+Refer to [coding-guidelines](./rust-coding-guidelines.md#integer-arithmetic).
 
 ### Error Handling
- Use `Result<T, E>` and `Option<T>` for error handling instead of *unwrapping* or *expecting*, to avoid panics [[error handling]](https://anssi-fr.github.io/rust-guide/04_language.html#error-handling) [[panic]](https://anssi-fr.github.io/rust-guide/04_language.html#panics) [[coding-style]](rust-coding-guidelines.md/#error-handling).
+
+Use `Result<T, E>` and `Option<T>` for error handling instead of _unwrapping_ or _expecting_, to avoid panics [[error handling]](https://anssi-fr.github.io/rust-guide/04_language.html#error-handling) [[panic]](https://anssi-fr.github.io/rust-guide/04_language.html#panics) [[coding-style]](rust-coding-guidelines.md/#error-handling).
 
 ### Assertions
- Prefer using `Result` and context-rich error handling over Rust's `assert!`, `assert_eq!`, and `assert_ne!` macros for enforcing invariants, reserving assertions for development and unrecoverable error scenarios.
+
+Prefer using `Result` and context-rich error handling over Rust's `assert!`, `assert_eq!`, and `assert_ne!` macros for enforcing invariants, reserving assertions for development and unrecoverable error scenarios.
 
 ## Types Systems and Data Structures
 
 ### Drop Trait
- Implement the `Drop` trait selectively and ensure it doesn't cause panics [[drop trait the destructor]](https://anssi-fr.github.io/rust-guide/06_typesystem.html#drop-trait-the-destructor).
-  - Implement the Drop trait selectively, only when necessary for specific destructor logic. It's mainly used for managing external resources or memory in structures like Box or Rc, often involving unsafe code and security-critical operations.
-  - In a Rust secure development, the implementation of the `std::ops::Drop` trait
-    must not panic.
-  - Do not rely on `Drop` trait in security material treatment after the use, use [zeroize](https://docs.rs/zeroize/latest/zeroize/#) to explicit destroy security material, e.g. private keys.
+
+Implement the `Drop` trait selectively and ensure it doesn't cause panics [[drop trait the destructor]](https://anssi-fr.github.io/rust-guide/06_typesystem.html#drop-trait-the-destructor).
+
+- Implement the Drop trait selectively, only when necessary for specific destructor logic. It's mainly used for managing external resources or memory in structures like Box or Rc, often involving unsafe code and security-critical operations.
+- In a Rust secure development, the implementation of the `std::ops::Drop` trait
+  must not panic.
+- Do not rely on `Drop` trait in security material treatment after the use, use [zeroize](https://docs.rs/zeroize/latest/zeroize/#) to explicit destroy security material, e.g. private keys.
 
 ### Send and Sync Traits
- Be cautious with manual implementations of `Send` and `Sync` traits [[Rustbook: typesystem]](https://anssi-fr.github.io/rust-guide/06_typesystem.html#send-and-sync-traits) [[Rustbook: send and sync]](https://doc.rust-lang.org/nomicon/send-and-sync.html).
-Both traits are *unsafe traits*, i.e., the Rust compiler does not verify in any way that they are implemented correctly. The danger is real: an incorrect implementation may lead to **undefined behavior**.
+
+Be cautious with manual implementations of `Send` and `Sync` traits [[Rustbook: typesystem]](https://anssi-fr.github.io/rust-guide/06_typesystem.html#send-and-sync-traits) [[Rustbook: send and sync]](https://doc.rust-lang.org/nomicon/send-and-sync.html).
+Both traits are _unsafe traits_, i.e., the Rust compiler does not verify in any way that they are implemented correctly. The danger is real: an incorrect implementation may lead to **undefined behavior**.
 
 In the majority of scenarios, manual implementation is unnecessary. In Rust, nearly all primitive types intrinsically implement Send and Sync traits, and for a significant proportion of compound types, the Rust compiler automatically derives these implementations.
 
 ### Comparison Traits
- Ensure the implementation of standard comparison traits respects documented invariants [[comparison traits partialeq eq partialord ord]](https://anssi-fr.github.io/rust-guide/06_typesystem.html#comparison-traits-partialeq-eq-partialord-ord).
+
+Ensure the implementation of standard comparison traits respects documented invariants [[comparison traits partialeq eq partialord ord]](https://anssi-fr.github.io/rust-guide/06_typesystem.html#comparison-traits-partialeq-eq-partialord-ord).
+
 > The ANSSI resource extensively covers the matter, an example in [Appendix](#implementation-of-comparison-traits) is provided as a really basic demonstration of implementation.
 
 ### Enums
- Prefer enums for state management to prevent invalid state representation.
+
+Prefer enums for state management to prevent invalid state representation.
 
 ### Concurrency Safe Primitives
+
 Make use of Rust’s concurrency primitives like `Arc`, `Mutex`, and `RwLock` to manage shared state [[Rustbook: concurrency]](https://doc.rust-lang.org/book/ch16-00-concurrency.html).
 By utilizing these primitives, Rust programs can manage shared resources among multiple threads safely and efficiently, adhering to Rust's goals of enabling fearless concurrency and memory safety. This is critical in multithread programs because mistakes in concurrency can be very costly, both for the system's stability and security.
 
 ### Data Structures with Deterministic Internal Order
-Certain data structures, like HashMap and HashSet, do not guarantee a deterministic order for the elements stored within them. This lack of order can lead to problems in operations that require processing elements in a consistent sequence across multiple executions. Below is a list of deterministic data structures available in Rust. Please note, this list may not be exhaustive:
-  - **BTreeMap:** It maintains its elements in sorted order by their keys.
-  - **BinaryHeap:** It maintains its elements in a heap order, which is a complete binary tree where each parent node is less than or equal to its child nodes.
-  - **VEC**: It maintains its elements in the order in which they were inserted. ⚠️
-  - **LinkedList:** It maintains its elements in the order in which they were inserted. ⚠️
-  - **VecDeque:** It maintains its elements in the order in which they were inserted. ⚠️
 
+Certain data structures, like HashMap and HashSet, do not guarantee a deterministic order for the elements stored within them. This lack of order can lead to problems in operations that require processing elements in a consistent sequence across multiple executions. Below is a list of deterministic data structures available in Rust. Please note, this list may not be exhaustive:
+
+- **BTreeMap:** It maintains its elements in sorted order by their keys.
+- **BinaryHeap:** It maintains its elements in a heap order, which is a complete binary tree where each parent node is less than or equal to its child nodes.
+- **VEC**: It maintains its elements in the order in which they were inserted. ⚠️
+- **LinkedList:** It maintains its elements in the order in which they were inserted. ⚠️
+- **VecDeque:** It maintains its elements in the order in which they were inserted. ⚠️
 
 ## Cryptography
 
 ### Talk to a cryptographer
- If you’re using cryptography in your code and you are **not** a cryptographer, you don’t know what you don’t know (*e.g.,* small subgroup attacks, malleability attacks, domain-separation attacks, collision resistance versus one-wayness, safe key reuse, correctly using randomness, nonce reuse, CCA security, CPA security, etc). So ask for help from a cryptographer in our team (Alin, Benny, Michael, Rex).
+
+If you’re using cryptography in your code and you are **not** a cryptographer, you don’t know what you don’t know (_e.g.,_ small subgroup attacks, malleability attacks, domain-separation attacks, collision resistance versus one-wayness, safe key reuse, correctly using randomness, nonce reuse, CCA security, CPA security, etc). So ask for help from a cryptographer in our team (Alin, Benny, Michael, Rex).
 
 ### No Custom Cryptographic Algorithm
+
 Use exclusively the cryptographic primitives exposed by the `aptos-crypto` crate. This does **not** mean you will be able to use them safely, so [talk to a cryptographer](#talk-to-a-cryptographer)!
 
 ### Cryptographic Material Management
+
 Adhere strictly to established protocols for generating, storing, and managing cryptographic keys. This includes using secure random sources for key generation, ensuring keys are stored in protected environments, and implementing robust management practices to handle key lifecycle events like rotation and revocation [[Key Management Cheat Sheet]](https://cheatsheetseries.owasp.org/cheatsheets/Key_Management_Cheat_Sheet.html).
 
 ### Zeroing Sensitive Data
+
 Use [zeroize](https://docs.rs/zeroize/latest/zeroize/#) for zeroing memory containing sensitive data.
 
 ## Misc
+
 ### Forget and Memory Leaks
+
 Avoid using `std::mem::forget` in secure development, or any other function that leaks the memory [[forget and memory leaks]](https://anssi-fr.github.io/rust-guide/05_memory.html#forget-and-memory-leaks).
+
 > Reference cycles can also cause memory leakage [[Rustbook: leak]](https://doc.rust-lang.org/book/ch15-06-reference-cycles.html?highlight=leak#reference-cycles-can-leak-memory).
 
 Most memory leaks result in general product reliability problems. If an attacker can intentionally trigger a memory leak, the attacker might be able to launch a denial-of-service attack (by crashing or hanging the program).
@@ -131,19 +161,19 @@ Most memory leaks result in general product reliability problems. If an attacker
 ## Appendix
 
 #### Implementation of Comparison Traits
-    
+
 ```rust
     use std::cmp::Ordering;
-    
+
     /// A struct representing a 2D point.
     #[derive(Debug)]
     struct Point {
         x: i32,
         y: i32,
     }
-    
+
     /// Implementing the PartialEq trait for Point.
-    /// 
+    ///
     /// This implementation respects the documented invariant that for any points a and b,
     /// a == b if and only if both their x and y coordinates are equal.
     impl PartialEq for Point {
@@ -152,9 +182,9 @@ Most memory leaks result in general product reliability problems. If an attacker
             self.x == other.x && self.y == other.y
         }
     }
-    
+
     /// Implementing the PartialOrd trait for Point.
-    /// 
+    ///
     /// The documented invariant here is that the points are ordered primarily by their x-coordinate,
     /// and then by their y-coordinate. This means that for any points a and b,
     /// a < b if a.x < b.x or if a.x == b.x and a.y < b.y.
@@ -170,50 +200,50 @@ Most memory leaks result in general product reliability problems. If an attacker
             }
         }
     }
-    
+
     #[cfg(test)]
     mod tests {
         use super::*;
-    
+
         #[test]
         fn test_equality() {
             let point1 = Point { x: 1, y: 2 };
             let point2 = Point { x: 1, y: 2 };
             let point3 = Point { x: 2, y: 3 };
-    
+
             assert_eq!(point1, point2, "Points with same coordinates should be equal");
             assert_ne!(point1, point3, "Points with different coordinates should not be equal");
         }
-    
+
         #[test]
         fn test_inequality() {
             let point1 = Point { x: 1, y: 2 };
             let point2 = Point { x: 1, y: 3 };
-    
+
             assert!(point1 != point2, "Points with different y coordinates should not be equal");
         }
-    
+
         #[test]
         fn test_less_than() {
             let point1 = Point { x: 1, y: 2 };
             let point2 = Point { x: 1, y: 3 };
             let point3 = Point { x: 2, y: 1 };
-    
+
             assert!(point1 < point2, "Point1 should be less than Point2 based on y-coordinate");
             assert!(point1 < point3, "Point1 should be less than Point3 based on x-coordinate");
         }
-    
+
         #[test]
         fn test_greater_than() {
             let point1 = Point { x: 1, y: 3 };
             let point2 = Point { x: 1, y: 2 };
             let point3 = Point { x: 2, y: 1 };
-    
+
             assert!(point1 > point2, "Point1 should be greater than Point2 based on y-coordinate");
             assert!(point3 > point2, "Point3 should be greater than Point2 based on x-coordinate");
         }
     }
-  ```
+```
 
 # Conclusion
 

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -135,13 +135,9 @@ Below is a list of deterministic data structures available in Rust. Please note,
 
 ## Cryptography
 
-### Talk to a cryptographer
-
-If you’re using cryptography in your code and you are **not** a cryptographer, you don’t know what you don’t know (_e.g.,_ small subgroup attacks, malleability attacks, domain-separation attacks, collision resistance versus one-wayness, safe key reuse, correctly using randomness, nonce reuse, CCA security, CPA security, etc). So ask for help from a cryptographer in our team (Alin, Benny, Michael, Rex).
-
 ### No Custom Cryptographic Algorithm
 
-Use exclusively the cryptographic primitives exposed by the `aptos-crypto` crate. This does **not** mean you will be able to use them safely, so [talk to a cryptographer](#talk-to-a-cryptographer)!
+Use exclusively the cryptographic primitives exposed by the `aptos-crypto` crate.
 
 ### Cryptographic Material Management
 

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -158,6 +158,9 @@ Avoid using `std::mem::forget` in secure development, or any other function that
 
 Most memory leaks result in general product reliability problems. If an attacker can intentionally trigger a memory leak, the attacker might be able to launch a denial-of-service attack (by crashing or hanging the program).
 
+### Fuzzing
+Aptos contains harnesses for fuzzing crash-prone code like deserializers, using [`libFuzzer`](https://llvm.org/docs/LibFuzzer.html) through [`cargo fuzz`](https://rust-fuzz.github.io/book/cargo-fuzz.html). For more examples, see the `testsuite/fuzzer` directory where find detailed README.md.
+
 ## Appendix
 
 #### Implementation of Comparison Traits

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -81,7 +81,7 @@ Refer to [coding-guidelines](./rust-coding-guidelines.md#integer-arithmetic).
 
 ### Error Handling
 
-Use `Result<T, E>` and `Option<T>` for error handling instead of _unwrapping_ or _expecting_, to avoid panics [[error handling]](https://anssi-fr.github.io/rust-guide/04_language.html#error-handling) [[panic]](https://anssi-fr.github.io/rust-guide/04_language.html#panics) [[coding-style]](rust-coding-guidelines.md/#error-handling).
+Use `Result<T, E>` and `Option<T>` for error handling instead of _unwrapping_ or _expecting_, to avoid panics [[error handling]](https://anssi-fr.github.io/rust-guide/04_language.html#error-handling) [[panic]](https://anssi-fr.github.io/rust-guide/04_language.html#panics) [[coding-style]](./rust-coding-guidelines.md/#error-handling).
 
 ### Assertions
 

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -110,7 +110,7 @@ In the majority of scenarios, manual implementation is unnecessary. In Rust, nea
 Ensure the implementation of standard comparison traits respects documented invariants.
 In the context of implementing standard comparison traits (like Eq, PartialEq, Ord, PartialOrd in Rust), respecting documented invariants means that the implementation of these traits should adhere to the properties and expectations defined by those invariants. For instance, if an invariant states that an object's identity is determined by certain fields, comparisons (equality, greater than, less than, etc.) must only consider those fields and ignore others. This ensures consistency, predictability, and correctness in how objects are compared, sorted, or considered equal within the Aptos Core.
 
-> The ANSSI resource extensively covers the matter [Appendix](#Appendix).
+> The ANSSI resource extensively covers the matter [References](#references).
 
 ### Enums
 

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -56,7 +56,7 @@ Document safety invariants and security considerations in code, especially for p
 
 ### Crate Quality and Security
 
-Assess and monitor the quality and maintenance of used crates, employing tools like `cargo-outdated` and `cargo-audit` for version management and vulnerability checking [[audit lib]](https://anssi-fr.github.io/rust-guide/03_libraries.html#libraries).
+Assess and monitor the quality and maintenance of crates that are being introduced to the codebase, employing tools like `cargo-outdated` and `cargo-audit` for version management and vulnerability checking [[audit lib]](https://anssi-fr.github.io/rust-guide/03_libraries.html#libraries).
 
 - Aptos utilizes **[Dependabot](https://github.com/dependabot)** to continuously monitor libraries. Our policy requires mandatory updates for critical and high-vulnerabilities, or upon impact evaluation given the context for medium and lower.
 - When vetting a new library, it's advisable to utilize deps.dev for evaluation. This site provides an OpenSSF scorecard containing essential information. As a guideline, libraries with an OpenSSF score of 7 or higher are typically safe to import. However, those scoring **below 7** must undergo discussion prior to importation.

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -13,7 +13,7 @@ Utilize Rustup for managing Rust toolchains. However, keep in mind that, from a 
 
 ### Stable Toolchain
 
-Development of a secure application must be done using a fully stable toolchain, for limiting potential compiler, runtime, or tool bugs [[toolchains considerations]](https://anssi-fr.github.io/rust-guide/02_devenv.html#stable-nightly-and-beta-toolchains).
+Aptos Core leverages Rust stable toolchain to limit potential compiler, runtime, or tooling bugs, or potential supply chain attacks in nightly releases.
 
 ### Cargo
 

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -1,6 +1,6 @@
 ---
 id: rust-secure-coding-guidelines
-title: Secure Coding
+title: Secure Coding for Aptos Core
 ---
 
 These Rust Secure Coding Guidelines are essential for anyone contributing to Aptos, reflecting our security-first approach. As Aptos is built with a primary focus on security, these guidelines, derived and adapted from ANSSI's Secure Rust Guidelines, are integral to maintaining the high standards of safety and robustness in aptos-core. Aptos contributors are encouraged to thoroughly understand and apply these principles in their work.
@@ -9,7 +9,7 @@ These Rust Secure Coding Guidelines are essential for anyone contributing to Apt
 
 ### Rustup
 
-Utilize Rustup for managing Rust toolchains. However, keep in mind that, from a security perspective, Rustup performs all downloads over HTTPS, but it does not yet validate signatures of downloads. Security is shifted to [create.io](http://create.io) and GitHub repository hosting the code [[rustup]](https://anssi-fr.github.io/rust-guide/02_devenv.html#rustup).
+Utilize Rustup for managing Rust toolchains. However, keep in mind that, from a security perspective, Rustup performs all downloads over HTTPS, but it does not yet validate signatures of downloads. Security is shifted to [create.io](http://create.io) and GitHub repository hosting the code [[rustup]](https://www.rust-lang.org/tools/install).
 
 ### Stable Toolchain
 
@@ -17,20 +17,20 @@ Aptos Core leverages Rust stable toolchain to limit potential compiler, runtime,
 
 ### Cargo
 
-Utilize Cargo for project management without overriding variables like `debug-assertions` and `overflow-checks` [[cargo]](https://anssi-fr.github.io/rust-guide/02_devenv.html#cargo).
+Utilize Cargo for project management without overriding variables like `debug-assertions` and `overflow-checks`.
 
 - **`debug-assertions`**: This variable controls whether debug assertions are enabled. Debug assertions are checks that are only present in debug builds. They are used to catching bugs during development by validating assumptions made in the code.
 - **`overflow-checks`**: This variable determines whether arithmetic overflow checks are performed. In Rust, when overflow checks are enabled (which is the default in debug mode), an integer operation that overflows will cause a panic in debug builds, preventing potential security vulnerabilities like buffer overflows.
 
 ### Linters and Formatters
 
-Regularly use tools like Clippy and Rustfmt for identifying potential issues and maintaining code style [[clippy]](https://anssi-fr.github.io/rust-guide/02_devenv.html#clippy) [[rustfmt]](https://anssi-fr.github.io/rust-guide/02_devenv.html#rustfmt). Aptos **enforces** Clippy during automated testing with additional rules, so ensure to run it locally to prevent CI/CD failures.
+Regularly use tools like Clippy and Rustfmt for identifying potential issues and maintaining code style. Aptos **enforces** Clippy during automated testing with additional rules, so ensure to run it locally to prevent CI/CD failures.
 
 Clippy with Aptos-specific configuration can be run locally via `cargo xclippy` or using rust-analyser in your preferred IDE following these [instructions](https://rust-analyzer.github.io/manual.html#clippy). Aptos uses directives in files and a per-directory configuration to turn on or off checks.
 
 ### Rustfix
 
-Apply `rustfix` for compiler warnings and edition transitions, but verify the automatic fixes to ensure that the recommendations match the purpose of the code [[rustfix]](https://anssi-fr.github.io/rust-guide/02_devenv.html#rustfix).
+Apply `rustfix` for compiler warnings and edition transitions, but verify the automatic fixes to ensure that the recommendations match the purpose of the code.
 
 ### Documentation
 
@@ -56,7 +56,7 @@ Document safety invariants and security considerations in code, especially for p
 
 ### Crate Quality and Security
 
-Assess and monitor the quality and maintenance of crates that are being introduced to the codebase, employing tools like `cargo-outdated` and `cargo-audit` for version management and vulnerability checking [[audit lib]](https://anssi-fr.github.io/rust-guide/03_libraries.html#libraries).
+Assess and monitor the quality and maintenance of crates that are being introduced to the codebase, employing tools like `cargo-outdated` and `cargo-audit` for version management and vulnerability checking.
 
 - Aptos utilizes **[Dependabot](https://github.com/dependabot)** to continuously monitor libraries. Our policy requires mandatory updates for critical and high-vulnerabilities, or upon impact evaluation given the context for medium and lower.
 - We recommend leveraging [deps.dev](https://deps.dev) to evaluate new third party crates. This site provides an OpenSSF stcorecard containing essential information. As a guideline, libraries with a score of 7 or higher are typically safe to import. However, those scoring **below 7** must be flagged during the PR and require a specific justification.
@@ -73,7 +73,7 @@ Be aware of Cargo's feature unification process. When multiple dependencies requ
 
 ### Unsafe Code
 
-Never use `unsafe` blocks unless as a last resort. Justify their use in a comment, detailing how the code is effectively safe to deploy [[unsafe code]](https://anssi-fr.github.io/rust-guide/04_language.html#unsafe-code).
+Never use `unsafe` blocks unless as a last resort. Justify their use in a comment, detailing how the code is effectively safe to deploy.
 
 ### Integer Overflows
 
@@ -81,7 +81,7 @@ Refer to [coding-guidelines](./rust-coding-guidelines.md#integer-arithmetic).
 
 ### Error Handling
 
-Use `Result<T, E>` and `Option<T>` for error handling instead of _unwrapping_ or _expecting_, to avoid panics [[error handling]](https://anssi-fr.github.io/rust-guide/04_language.html#error-handling) [[panic]](https://anssi-fr.github.io/rust-guide/04_language.html#panics) [[coding-style]](./rust-coding-guidelines.md/#error-handling).
+Use `Result<T, E>` and `Option<T>` for error handling instead of _unwrapping_ or _expecting_, to avoid panics [[coding-style]](./rust-coding-guidelines.md/#error-handling).
 
 ### Assertions
 
@@ -91,12 +91,12 @@ Prefer using `Result` and context-rich error handling over Rust's `assert!`, `as
 
 ### Drop Trait
 
-Implement the `Drop` trait selectively and ensure it doesn't cause panics [[drop trait the destructor]](https://anssi-fr.github.io/rust-guide/06_typesystem.html#drop-trait-the-destructor).
+Implement the `Drop` trait selectively, only when necessary for specific destructor logic. It's mainly used for managing external resources or memory in structures like Box or Rc, often involving unsafe code and security-critical operations.
 
-- Implement the Drop trait selectively, only when necessary for specific destructor logic. It's mainly used for managing external resources or memory in structures like Box or Rc, often involving unsafe code and security-critical operations.
-- In a Rust secure development, the implementation of the `std::ops::Drop` trait
-  must not panic.
-- Do not rely on `Drop` trait in security material treatment after the use, use [zeroize](https://docs.rs/zeroize/latest/zeroize/#) to explicit destroy security material, e.g. private keys.
+In a Rust secure development, the implementation of the `std::ops::Drop` trait
+must not panic.
+
+> Do not rely on `Drop` trait in security material treatment after the use, use [zeroize](https://docs.rs/zeroize/latest/zeroize/#) to explicit destroy security material, e.g. private keys.
 
 ### Send and Sync Traits
 
@@ -107,7 +107,8 @@ In the majority of scenarios, manual implementation is unnecessary. In Rust, nea
 
 ### Comparison Traits
 
-Ensure the implementation of standard comparison traits respects documented invariants [[comparison traits partialeq eq partialord ord]](https://anssi-fr.github.io/rust-guide/06_typesystem.html#comparison-traits-partialeq-eq-partialord-ord).
+Ensure the implementation of standard comparison traits respects documented invariants.
+In the context of implementing standard comparison traits (like Eq, PartialEq, Ord, PartialOrd in Rust), respecting documented invariants means that the implementation of these traits should adhere to the properties and expectations defined by those invariants. For instance, if an invariant states that an object's identity is determined by certain fields, comparisons (equality, greater than, less than, etc.) must only consider those fields and ignore others. This ensures consistency, predictability, and correctness in how objects are compared, sorted, or considered equal within the Aptos Core.
 
 > The ANSSI resource extensively covers the matter, an example in [Appendix](#implementation-of-comparison-traits) is provided as a really basic demonstration of implementation.
 
@@ -122,7 +123,9 @@ By utilizing these primitives, Rust programs can manage shared resources among m
 
 ### Data Structures with Deterministic Internal Order
 
-Certain data structures, like HashMap and HashSet, do not guarantee a deterministic order for the elements stored within them. This lack of order can lead to problems in operations that require processing elements in a consistent sequence across multiple executions. Below is a list of deterministic data structures available in Rust. Please note, this list may not be exhaustive:
+Certain data structures, like HashMap and HashSet, do not guarantee a deterministic order for the elements stored within them. This lack of order can lead to problems in operations that require processing elements in a consistent sequence across multiple executions. In the Aptos blockchain, deterministic data structures help in achieving consensus, maintaining the integrity of the ledger, and ensuring that computations can be reliably reproduced across different nodes.
+
+Below is a list of deterministic data structures available in Rust. Please note, this list may not be exhaustive:
 
 - **BTreeMap:** maintains its elements in sorted order by their keys.
 - **BinaryHeap:** It maintains its elements in a heap order, which is a complete binary tree where each parent node is less than or equal to its child nodes.
@@ -152,16 +155,21 @@ Use [zeroize](https://docs.rs/zeroize/latest/zeroize/#) for zeroing memory conta
 
 ### Forget and Memory Leaks
 
-Avoid using `std::mem::forget` in secure development, or any other function that leaks the memory [[forget and memory leaks]](https://anssi-fr.github.io/rust-guide/05_memory.html#forget-and-memory-leaks).
+Avoid using `std::mem::forget` in secure development, or any other function that leaks the memory.
 
 > Reference cycles can also cause memory leakage [[Rustbook: leak]](https://doc.rust-lang.org/book/ch15-06-reference-cycles.html?highlight=leak#reference-cycles-can-leak-memory).
 
 Most memory leaks result in general product reliability problems. If an attacker can intentionally trigger a memory leak, the attacker might be able to launch a denial-of-service attack (by crashing or hanging the program).
 
 ### Fuzzing
+
 Aptos contains harnesses for fuzzing crash-prone code like deserializers, using [`libFuzzer`](https://llvm.org/docs/LibFuzzer.html) through [`cargo fuzz`](https://rust-fuzz.github.io/book/cargo-fuzz.html). For more examples, see the `testsuite/fuzzer` directory where find detailed README.md.
 
 ## Appendix
+
+#### References
+
+- ANSSI's Secure Rust Guidelines: https://anssi-fr.github.io/rust-guide/
 
 #### Implementation of Comparison Traits
 

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -81,7 +81,7 @@ Refer to [coding-guidelines](./rust-coding-guidelines.md#integer-arithmetic).
 
 ### Error Handling
 
-Use `Result<T, E>` and `Option<T>` for error handling instead of _unwrapping_ or _expecting_, to avoid panics [[coding-style]](./rust-coding-guidelines.md/#error-handling).
+Use `Result<T, E>` and `Option<T>` for error handling instead of _unwrapping_ or _expecting_, to avoid panics [[coding-style]](./rust-coding-guidelines.md#error-handling).
 
 ### Assertions
 

--- a/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
+++ b/docs/community/rust-coding-guidelines/rust-secure-coding-guidelines.md
@@ -36,22 +36,6 @@ Apply `rustfix` for compiler warnings and edition transitions, but verify the au
 
 Document safety invariants and security considerations in code, especially for public and `unsafe` functions.
 
-````rust
-  foo(
-      // SAFETY:
-      // This is a valid safety comment
-      unsafe { *x }
-  )
-  ```
-
-  ```rust
-  use std::ptr::NonNull;
-  let a = &mut 42;
-
-  // SAFETY: references are guaranteed to be non-null.
-  let ptr = unsafe { NonNull::new_unchecked(a) };
-````
-
 ## Libraries
 
 ### Crate Quality and Security
@@ -74,6 +58,21 @@ Be aware of Cargo's feature unification process. When multiple dependencies requ
 ### Unsafe Code
 
 Never use `unsafe` blocks unless as a last resort. Justify their use in a comment, detailing how the code is effectively safe to deploy.
+
+```rust
+  foo(
+      // SAFETY:
+      // This is a valid safety comment
+      unsafe { *x }
+  )
+```
+```rust
+  use std::ptr::NonNull;
+  let a = &mut 42;
+
+  // SAFETY: references are guaranteed to be non-null.
+  let ptr = unsafe { NonNull::new_unchecked(a) };
+````
 
 ### Integer Overflows
 

--- a/scripts/additional_dict.txt
+++ b/scripts/additional_dict.txt
@@ -503,3 +503,13 @@ xlarge
 yaml
 yamls
 zkSNARK
+ANSSI's
+Rustup
+toolchains
+HTTPS
+Rustfix
+Eq
+PartialEq
+Ord
+PartialOrd
+ANSSI

--- a/src/components/sidebars.ts
+++ b/src/components/sidebars.ts
@@ -622,8 +622,8 @@ const sidebars: SidebarsConfig = {
       type: "category",
       label: "Rust Coding Guidelines",
       items: [
-      "community/rust-coding-guidelines/rust-coding-guidelines",
-      "community/rust-coding-guidelines/rust-secure-coding-guidelines",
+        "community/rust-coding-guidelines/rust-coding-guidelines",
+        "community/rust-coding-guidelines/rust-secure-coding-guidelines",
       ],
     },
     "community/site-updates",

--- a/src/components/sidebars.ts
+++ b/src/components/sidebars.ts
@@ -618,7 +618,14 @@ const sidebars: SidebarsConfig = {
     },
     "community/index",
     "community/external-resources",
-    "community/rust-coding-guidelines",
+    {
+      type: "category",
+      label: "Rust Coding Guidelines",
+      items: [
+      "community/rust-coding-guidelines/rust-coding-guidelines",
+      "community/rust-coding-guidelines/rust-secure-coding-guidelines",
+      ],
+    },
     "community/site-updates",
     "community/aptos-style",
     "community/contributors",


### PR DESCRIPTION
### Description
The first version of the Aptos Rust Secure Coding Guidelines, introduced alongside the coding ones.

New folder structure:
```
├── community
│   ├── aptos-style.md
│   ├── contributions
│   │   └── remix-ide-plugin.md
│   ├── contributors.md
│   ├── external-resources.md
│   ├── index.md
│   ├── rust-coding-guidelines <-- Rust guidelines grouped under one folder
│   │   ├── rust-coding-guidelines.md
│   │   └── rust-secure-coding-guidelines.md
│   └── site-updates.md
```

### Checklist

- [X] Do all Lints pass?
- [X] Have you ran `pnpm spellcheck`?
- [X] Have you ran `pnpm fmt`?
- [X] Have you ran `pnpm lint`?
