### PR TITLE
[Node] Pass over node configuration section

### DIFF
--- a/docs/guides/data-pruning.md
+++ b/docs/guides/data-pruning.md
@@ -2,35 +2,26 @@
 title: "Data Pruning"
 ---
 
-When a validator node is running, it participates in consensus to execute
-transactions and commit new data to the blockchain. Similarly, when fullnodes
-are running, they sync the new blockchain data through [state synchronization](../guides/state-sync.md).
-As the blockchain grows, storage disk space can be managed by pruning old
-blockchain data. Specifically, by pruning the **ledger history**: which
-contains old transactions. By default, ledger pruning is enabled on all
-nodes with a pruning window that can be configured. This document describes
-how you can configure the pruning behavior.
+All Aptos nodes (e.g., validators, VFNs and PFNs) process transactions and commit new data to the blockchain.
+As the blockchain grows (indefinitely), nodes can manage the amount of storage disk space required by pruning old
+blockchain data. To achieve this, Aptos nodes prune the blockchain **ledger history** in their database, which
+contains the history of all transactions. The ledger history may be **complete** (e.g., if you're operating an archival
+node), or **pruned** to a certain window of transactions (to reduce storage requirements).
 
-:::note
-By default the ledger pruner keeps 150 million recent transactions. The approximate amount of disk space required for every 150M transactions is 200G. Unless
-bootstrapped from the genesis and configured to disable the pruner or a long
-prune window, the node doesn't carry the entirety of the ledger history.
-Majority of the nodes on both the testnet and mainnet have a partial
-history of 150 million transactions according to this configuration.
+By default, ledger pruning is enabled on all nodes, and the pruning window can be configured. This document
+describes how you can configure the behavior of the ledger pruner.
+
+:::tip Default pruning window
+The default configuration of the ledger pruner is to keep only the most recent 150 million transactions.
+This roughly corresponds to around ~200G of disk space, depending on transaction types and outputs.
+Almost all Aptos nodes in testnet and mainnet use the default configuration. If you instead wish to run
+an archival node, follow the instructions, [here](../guides/state-sync.md#archival-pfns).
 :::
 
-To manage these settings, edit the node configuration YAML files,
-for example, `fullnode.yaml` for fullnodes (validator or public) or
-`validator.yaml` for validator nodes, as shown below.
+## Disable the ledger pruner
 
-## Disabling the ledger pruner
-
-Add the following to the node configuration YAML file to disable the
-ledger pruner:
-
-:::caution Proceed with caution
-Disabling the ledger pruner can result in the storage disk filling up very quickly.
-:::
+If you wish to disable the ledger pruner entirely, you can do so by adding the following to the node
+configuration file, e.g., `fullnode.yaml` or `validator.yaml`.
 
 ```yaml
 storage:
@@ -39,21 +30,24 @@ storage:
       enable: false
 ```
 
-## Configuring the ledger pruning window
-
-Add the following to the node configuration YAML file to make the node
-retain, for example, 1 billion transactions and their outputs, including events
-and write sets.
-
-:::caution Proceed with caution
-Setting the pruning window smaller than 100 million can lead to runtime errors and damage the health of the node.
+:::danger Unbounded storage growth
+Be warned that disabling the ledger pruner will result in unbounded storage growth. This can
+lead to the storage disk filling up very quickly.
 :::
+
+## Configure the ledger pruner
+
+If you wish, you can configure the size of the ledger pruning window (i.e., the number of the most recent transactions
+to retain in storage). To do this, add the following to the node configuration file, e.g., `fullnode.yaml` or `validator.yaml`.
 
 ```yaml
 storage:
   storage_pruner_config:
     ledger_pruner_config:
-      prune_window: 1000000000
+      prune_window: 100000000 # 100 million transactions
 ```
 
-See the complete set of storage configuration settings in the [Storage README](https://github.com/aptos-labs/aptos-core/tree/main/storage#configs).
+:::danger Minimum pruning window
+Setting the pruning window smaller than 100 million transactions can lead to runtime errors and damage the
+health of the node.
+:::

--- a/docs/guides/state-sync.md
+++ b/docs/guides/state-sync.md
@@ -5,29 +5,35 @@ title: "State Synchronization"
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-Nodes in an Aptos network must always be synchronized to the latest Aptos blockchain state, e.g., validators, validator
-fullnodes (VFNs) and public fullnodes (PFNs). The [state synchronization](https://medium.com/aptoslabs/the-evolution-of-state-sync-the-path-to-100k-transactions-per-second-with-sub-second-latency-at-52e25a2c6f10) (state sync) component that runs on each
-node is responsible for this. State sync identifies and fetches new blockchain data from the peers, validates the data
-and persists it to local storage.
+Nodes in an Aptos network (e.g., validators, VFNs and PFNs) must always be synchronized to the latest blockchain state.
+The [state synchronization](https://medium.com/aptoslabs/the-evolution-of-state-sync-the-path-to-100k-transactions-per-second-with-sub-second-latency-at-52e25a2c6f10) (state sync) component that runs on each node is responsible for this. State sync
+identifies and fetches new blockchain data from the peers, validates the data and persists it to local storage. This
+document explains how state sync works and how to configure it.
+
+:::danger Manual configuration
+Most users should not need to configure state sync. State sync will automatically select the
+best configuration for your node. You should only manually configure state sync if you have a specific use case
+that requires it. Selecting the wrong configuration will lead to slower syncing times and degraded performance.
+:::
+
+## State sync
+
+At a high-level, state sync operates in two phases. First, all nodes will bootstrap on startup (in the **bootstrapping phase**).
+This allows the node to catch up to the latest state in the Aptos blockchain. Next, the node will stay up-to-date with the blockchain
+by continuously syncing (in the **continuous syncing phase**). Each of these phases has different modes of operation.
 
 :::tip Need to start a node quickly?
-If you need to start a node quickly, here's what we recommend (by use case):
+If you need to start a node quickly, here's what we recommend by network and use case:
 
-- **Devnet PFN**: To sync the entire blockchain history, use [intelligent syncing](state-sync.md#intelligent-syncing). Otherwise, use [fast sync](state-sync.md#fast-syncing).
-- **Testnet PFN**: To sync the entire blockchain history, restore from a [backup](../nodes/full-node/aptos-db-restore.md). Otherwise, download [a snapshot](../nodes/full-node/bootstrap-fullnode.md) or use [fast sync](state-sync.md#fast-syncing).
-- **Mainnet PFN**: To sync the entire blockchain history, restore from a [backup](../nodes/full-node/aptos-db-restore.md). Otherwise, use [fast sync](state-sync.md#fast-syncing).
-- **Mainnet validator or VFN**: To sync the entire blockchain history, restore from a [backup](../nodes/full-node/aptos-db-restore.md). Otherwise, use [fast sync](state-sync.md#fast-syncing).
+- **Devnet**: To sync the entire blockchain history, use [intelligent syncing](state-sync.md#intelligent-syncing). Otherwise, use [fast sync](state-sync.md#fast-syncing).
+- **Testnet**: To sync the entire blockchain history, restore from a [backup](../nodes/full-node/aptos-db-restore.md). Otherwise, download [a snapshot](../nodes/full-node/bootstrap-fullnode.md) or use [fast sync](state-sync.md#fast-syncing).
+- **Mainnet**: To sync the entire blockchain history, restore from a [backup](../nodes/full-node/aptos-db-restore.md). Otherwise, use [fast sync](state-sync.md#fast-syncing).
   :::
-
-## State sync phases
-
-State sync runs in two phases. All nodes will first bootstrap on startup (in the **bootstrapping phase**), and then
-continuously synchronize (in the **continuous syncing phase**).
 
 ### Bootstrapping phase
 
-When the node starts, state sync will perform bootstrapping by using the configured bootstrapping mode. This allows the
-node to catch up to the latest state in the Aptos blockchain. There are several bootstrapping modes:
+When the node starts, state sync will perform bootstrapping by using the configured bootstrapping mode. There are several
+bootstrapping modes:
 
 - **Execute all the transactions since genesis**. In this mode, the node will retrieve from the Aptos network all the
   transactions since genesis, i.e., since the start of the blockchain's history, and re-execute those transactions.
@@ -72,13 +78,12 @@ The default continuous syncing mode is always intelligent syncing, because this 
 
 ## Configuring state sync
 
-The configuration snippets below provide instructions for configuring state sync on your nodes for different use cases.
+The snippets below provide instructions for configuring state sync on your nodes for different use cases.
 These configurations can be added to your node's configuration file, e.g., `fullnode.yaml` or `validator.yaml`.
 
 :::danger Manual configuration
-State sync is tuned to automatically select the best mode for your node, depending on the network.
-Be aware that if you manually configure your node to use a different mode, it may not be the most
-optimal, and you could experience slower syncing times and degraded performance.
+You should only manually configure state sync if you have a specific use case that requires it. Selecting the wrong
+configuration will lead to slower syncing times and degraded performance.
 :::
 
 ### Executing all transactions
@@ -170,14 +175,19 @@ increase then do the following:
    (i.e., that it has not synced any state previously).
    :::
 
-## Running archival PFNs
+## Archival PFNs
 
 To operate an archival PFN (which is a PFN that contains all blockchain data
 since the start of the network, i.e., genesis), you should:
 
-1. Configure the PFN _not to use_ fast syncing, e.g., select intelligent syncing in your node configuration file.
+1. Make sure that your PFN is **not** using fast syncing as the bootstrapping mode.
+   Fast syncing will skip the transaction history. Instead, using a mode that syncs from genesis,
+   e.g., intelligent syncing from genesis.
 2. Disable the ledger pruner, as described in the [Data Pruning document](data-pruning.md#disabling-the-ledger-pruner).
    This will ensure that no data is deleted and the PFN contains all blockchain data.
+
+Following these two steps together will ensure that your PFN fetches all data since
+genesis, and continues to synchronize without pruning any data.
 
 :::danger Archival nodes have ever-growing storage
 Running and maintaining archival nodes is likely to be expensive and slow
@@ -201,7 +211,10 @@ each syncing mode:
    have executed the transactions correctly. However, all other
    blockchain state is still manually re-verified, e.g., consensus messages,
    the transaction history and the state hashes are still verified.
-3. **Fast syncing**: Fast syncing skips the transaction history and downloads the latest
+3. **Intelligent syncing**: Intelligent syncing will either execute or apply the transaction outputs
+   depending on whichever is faster, per data chunk. Thus, the security implications of using this mode
+   are identical to those of applying transaction outputs.
+4. **Fast syncing**: Fast syncing skips the transaction history and downloads the latest
    blockchain state before continuously syncing. To do this, it requires that the
    syncing node trust the validators to have correctly agreed upon all
    transactions in the transaction history as well as trust that all transactions

--- a/docs/nodes/configure/index.md
+++ b/docs/nodes/configure/index.md
@@ -1,0 +1,13 @@
+---
+title: "Configure a Node"
+slug: "configure-index"
+---
+
+# Configure a Node
+
+This section contains tutorials for understanding and configuring Aptos node internals. These include:
+
+- ### [Configuring state synchronization](../../guides/state-sync.md)
+- ### [Configuring data pruning](../../guides/data-pruning.md)
+- ### [Configuring telemetry](../../reference/telemetry.md)
+- ### [Understanding node files](../node-files-all-networks/node-files.md)

--- a/docs/nodes/node-files-all-networks/index.md
+++ b/docs/nodes/node-files-all-networks/index.md
@@ -1,0 +1,13 @@
+---
+title: "Locating Node Files"
+slug: "node-files-index"
+---
+
+# Locating Node Files
+
+This section contains pages for locating and downloading the files required to deploy an Aptos node
+on different networks. These include:
+
+- ### [Files For Mainnet](./node-files.md)
+- ### [Files For Testnet](./node-files-testnet.md)
+- ### [Files For Devnet](./node-files-devnet.md)

--- a/docs/nodes/node-files-all-networks/node-files-devnet.md
+++ b/docs/nodes/node-files-all-networks/node-files-devnet.md
@@ -1,24 +1,23 @@
 ---
-title: "Node Files For Devnet"
+title: "Files For Devnet"
 slug: "node-files-devnet"
 ---
 
-# Node Files For Devnet
+# Files For Devnet
 
-When you are deploying an Aptos node in the **devnet**, you will need to download the files listed on this page.
+When deploying an Aptos node in **devnet**, you may need to download the files listed on this page. The files are
+organized by node type.
 
-- **Mainnet:** If you are deploying in the mainnet, download the files from the [Node Files For Mainnet](./node-files.md) page.
-- **Testnet:** If you are deploying in the testnet, download the files from the [Node Files For Testnet](./node-files-testnet.md) page.
-
----
-
-These files can be downloaded from separate `aptos-labs` repos on GitHub. The `wget` commands provided below will work on macOS and Linux. Open a terminal and paste the `wget` command to download the file.
-
-:::tip Files for the validator node
-Unless specified, all these files are required for validator node. A file with `fullnode` in its filename is required for either a validator fullnode or a public fullnode.
+:::tip file access
+Depending on the type of node your are deploying, and the deployment method, you may need to download some
+or all of the files listed below.
 :::
 
-## docker-compose.yaml
+## Validator Files
+
+All the files listed below are for validator nodes.
+
+### docker-compose.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `devnet` on https://github.com/aptos-labs/aptos-core
@@ -27,7 +26,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O docker-compose.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/devnet/docker/compose/aptos-node/docker-compose.yaml
   ```
 
-## validator.yaml
+### validator.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `devnet` on https://github.com/aptos-labs/aptos-core
@@ -36,7 +35,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O validator.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/devnet/docker/compose/aptos-node/validator.yaml
   ```
 
-## genesis.blob
+### genesis.blob
 
 - **Git repo:** `aptos-networks`
 - **Git branch:** `main` on https://github.com/aptos-labs/aptos-networks
@@ -45,7 +44,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O genesis.blob https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/devnet/genesis.blob
   ```
 
-## waypoint.txt
+### waypoint.txt
 
 - **Git repo:** `aptos-networks`
 - **Git branch:** `main` on https://github.com/aptos-labs/aptos-networks
@@ -54,7 +53,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O waypoint.txt https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/devnet/waypoint.txt
   ```
 
-## docker-compose-src.yaml
+### docker-compose-src.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `devnet` on https://github.com/aptos-labs/aptos-core
@@ -63,7 +62,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O docker-compose-src.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/devnet/docker/compose/aptos-node/docker-compose-src.yaml
   ```
 
-## haproxy.cfg
+### haproxy.cfg
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `devnet` on https://github.com/aptos-labs/aptos-core
@@ -72,7 +71,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O haproxy.cfg https://raw.githubusercontent.com/aptos-labs/aptos-core/devnet/docker/compose/aptos-node/haproxy.cfg
   ```
 
-## blocked.ips
+### blocked.ips
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `devnet` on https://github.com/aptos-labs/aptos-core
@@ -81,11 +80,11 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O blocked.ips https://raw.githubusercontent.com/aptos-labs/aptos-core/devnet/docker/compose/aptos-node/blocked.ips
   ```
 
-## docker-compose-fullnode.yaml (fullnode only)
+## VFN or PFN files
 
-:::tip Fullnode
-Fullnode means either a validator fullnode or a public fullnode.
-:::
+The files listed below are for VFNs or PFNs.
+
+### docker-compose-fullnode.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `devnet` on https://github.com/aptos-labs/aptos-core
@@ -94,11 +93,7 @@ Fullnode means either a validator fullnode or a public fullnode.
   wget -O docker-compose-fullnode.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/devnet/docker/compose/aptos-node/docker-compose-fullnode.yaml
   ```
 
-## fullnode.yaml (fullnode only)
-
-:::tip Fullnode
-Fullnode means either a validator fullnode or a public fullnode.
-:::
+### fullnode.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `devnet` on https://github.com/aptos-labs/aptos-core
@@ -107,7 +102,7 @@ Fullnode means either a validator fullnode or a public fullnode.
   wget -O fullnode.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/devnet/docker/compose/aptos-node/fullnode.yaml
   ```
 
-## haproxy-fullnode.cfg (fullnode only)
+### haproxy-fullnode.cfg
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `devnet` on https://github.com/aptos-labs/aptos-core

--- a/docs/nodes/node-files-all-networks/node-files-testnet.md
+++ b/docs/nodes/node-files-all-networks/node-files-testnet.md
@@ -1,24 +1,23 @@
 ---
-title: "Node Files For Testnet"
+title: "Files For Testnet"
 slug: "node-files-testnet"
 ---
 
-# Node Files For Testnet
+# Files For Testnet
 
-When you are deploying an Aptos node in the **testnet**, you will need to download the files listed on this page.
+When deploying an Aptos node in **testnet**, you may need to download the files listed on this page. The files are
+organized by node type.
 
-- **Mainnet:** If you are deploying in the mainnet, download the files from the [Node Files For Mainnet](./node-files.md) page.
-- **Devnet:** If you are deploying in the testnet, download the files from the [Node Files For Devnet](./node-files-devnet.md) page.
-
----
-
-These files can be downloaded from separate `aptos-labs` repos on GitHub. The `wget` commands provided below will work on macOS and Linux. Open a terminal and paste the `wget` command to download the file.
-
-:::tip Files for the validator node
-Unless specified, all these files are required for validator node. A file with `fullnode` in its filename is required for either a validator fullnode or a public fullnode.
+:::tip file access
+Depending on the type of node your are deploying, and the deployment method, you may need to download some
+or all of the files listed below.
 :::
 
-## docker-compose.yaml
+## Validator Files
+
+All the files listed below are for validator nodes.
+
+### docker-compose.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `testnet` on https://github.com/aptos-labs/aptos-core
@@ -27,7 +26,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O docker-compose.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/testnet/docker/compose/aptos-node/docker-compose.yaml
   ```
 
-## validator.yaml
+### validator.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `testnet` on https://github.com/aptos-labs/aptos-core
@@ -36,7 +35,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O validator.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/testnet/docker/compose/aptos-node/validator.yaml
   ```
 
-## genesis.blob
+### genesis.blob
 
 - **Git repo:** `aptos-networks`
 - **Git branch:** `main` on https://github.com/aptos-labs/aptos-networks
@@ -45,7 +44,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O genesis.blob https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/testnet/genesis.blob
   ```
 
-## waypoint.txt
+### waypoint.txt
 
 - **Git repo:** `aptos-networks`
 - **Git branch:** `main` on https://github.com/aptos-labs/aptos-networks
@@ -54,7 +53,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O waypoint.txt https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/testnet/waypoint.txt
   ```
 
-## docker-compose-src.yaml
+### docker-compose-src.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `testnet` on https://github.com/aptos-labs/aptos-core
@@ -63,7 +62,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O docker-compose-src.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/testnet/docker/compose/aptos-node/docker-compose-src.yaml
   ```
 
-## haproxy.cfg
+### haproxy.cfg
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `testnet` on https://github.com/aptos-labs/aptos-core
@@ -72,7 +71,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O haproxy.cfg https://raw.githubusercontent.com/aptos-labs/aptos-core/testnet/docker/compose/aptos-node/haproxy.cfg
   ```
 
-## blocked.ips
+### blocked.ips
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `testnet` on https://github.com/aptos-labs/aptos-core
@@ -81,11 +80,11 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O blocked.ips https://raw.githubusercontent.com/aptos-labs/aptos-core/testnet/docker/compose/aptos-node/blocked.ips
   ```
 
-## docker-compose-fullnode.yaml (fullnode only)
+## VFN or PFN files
 
-:::tip Fullnode
-Fullnode means either a validator fullnode or a public fullnode.
-:::
+The files listed below are for VFNs or PFNs.
+
+## docker-compose-fullnode.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `testnet` on https://github.com/aptos-labs/aptos-core
@@ -94,11 +93,7 @@ Fullnode means either a validator fullnode or a public fullnode.
   wget -O docker-compose-fullnode.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/testnet/docker/compose/aptos-node/docker-compose-fullnode.yaml
   ```
 
-## fullnode.yaml (fullnode only)
-
-:::tip Fullnode
-Fullnode means either a validator fullnode or a public fullnode.
-:::
+## fullnode.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `testnet` on https://github.com/aptos-labs/aptos-core
@@ -107,7 +102,7 @@ Fullnode means either a validator fullnode or a public fullnode.
   wget -O fullnode.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/testnet/docker/compose/aptos-node/fullnode.yaml
   ```
 
-## haproxy-fullnode.cfg (fullnode only)
+## haproxy-fullnode.cfg
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `testnet` on https://github.com/aptos-labs/aptos-core

--- a/docs/nodes/node-files-all-networks/node-files.md
+++ b/docs/nodes/node-files-all-networks/node-files.md
@@ -1,21 +1,20 @@
 ---
-title: "Node Files For Mainnet"
+title: "Files For Mainnet"
 ---
 
-When you are deploying an Aptos node in the **mainnet**, you will need to download the files listed on this page.
+When deploying an Aptos node in **mainnet**, you may need to download the files listed on this page. The files are
+organized by node type.
 
-- **Devnet:** If you are deploying in the devnet, download the files from the [Node Files For Devnet](./node-files-devnet.md) page.
-- **Testnet:** If you are deploying in the testnet, download the files from the [Node Files For Testnet](./node-files-testnet.md) page.
-
----
-
-These files can be downloaded from separate `aptos-labs` repos on GitHub. The `wget` commands provided below will work on macOS and Linux. Open a terminal and paste the `wget` command to download the file.
-
-:::tip Files for the validator node
-Unless specified, all these files are required for validator node. A file with `fullnode` in its filename is required for either a validator fullnode or a public fullnode.
+:::tip file access
+Depending on the type of node your are deploying, and the deployment method, you may need to download some
+or all of the files listed below.
 :::
 
-## docker-compose.yaml
+## Validator Files
+
+All the files listed below are for validator nodes.
+
+### docker-compose.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
@@ -24,7 +23,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O docker-compose.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose.yaml
   ```
 
-## validator.yaml
+### validator.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
@@ -33,7 +32,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O validator.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/validator.yaml
   ```
 
-## genesis.blob
+### genesis.blob
 
 - **Git repo:** `aptos-networks`
 - **Git branch:** `main` on https://github.com/aptos-labs/aptos-networks
@@ -42,7 +41,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O genesis.blob https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/mainnet/genesis.blob
   ```
 
-## waypoint.txt
+### waypoint.txt
 
 - **Git repo:** `aptos-networks`
 - **Git branch:** `main` on https://github.com/aptos-labs/aptos-networks
@@ -51,7 +50,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O waypoint.txt https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/mainnet/waypoint.txt
   ```
 
-## docker-compose-src.yaml
+### docker-compose-src.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
@@ -60,7 +59,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O docker-compose-src.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose-src.yaml
   ```
 
-## haproxy.cfg
+### haproxy.cfg
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
@@ -69,7 +68,7 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O haproxy.cfg https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/haproxy.cfg
   ```
 
-## blocked.ips
+### blocked.ips
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
@@ -78,11 +77,13 @@ Unless specified, all these files are required for validator node. A file with `
   wget -O blocked.ips https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/blocked.ips
   ```
 
-## docker-compose-fullnode.yaml (fullnode only)
+---
 
-:::tip Fullnode
-Fullnode means either a validator fullnode or a public fullnode.
-:::
+## VFN or PFN files
+
+The files listed below are for VFNs or PFNs.
+
+### docker-compose-fullnode.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
@@ -91,11 +92,7 @@ Fullnode means either a validator fullnode or a public fullnode.
   wget -O docker-compose-fullnode.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose-fullnode.yaml
   ```
 
-## fullnode.yaml (fullnode only)
-
-:::tip Fullnode
-Fullnode means either a validator fullnode or a public fullnode.
-:::
+### fullnode.yaml
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
@@ -104,7 +101,7 @@ Fullnode means either a validator fullnode or a public fullnode.
   wget -O fullnode.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/fullnode.yaml
   ```
 
-## haproxy-fullnode.cfg (fullnode only)
+### haproxy-fullnode.cfg
 
 - **Git repo:** `aptos-core`
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core

--- a/docs/nodes/nodes-landing.md
+++ b/docs/nodes/nodes-landing.md
@@ -6,14 +6,14 @@ hide_table_of_contents: true
 The Aptos network consists of three node types: validator nodes, validator fullnodes (VFNs), and public fullnodes (PFNs). To
 participate in consensus, you are required to run a validator node and stake the minimum amount of utility coins. VFNs and PFNs
 are not required to participate in consensus, but they are necessary to distribute blockchain data and enable ecosystem services,
-e.g., indexing, querying, and RESTful API services (see [Aptos APIs](../apis)). You can learn more about the different types
-of nodes in the [Blockchain Deep Dive](../concepts/blockchain.md) section.
+e.g., indexing, querying, and RESTful API services (see [Aptos APIs](../apis)). VFNs can only be run by validator operators,
+while PFNs can be run by anyone. You can learn more about the different types of nodes in the [Blockchain Deep Dive](../concepts/blockchain.md) section.
 
 This section provides detailed, step-by-step instructions on how to deploy and operate Aptos nodes in different
 environments. It also describes everything you need to stake and participate in consensus and governance. You can also
 find additional resources for node operation in the [External Resources](../community/external-resources.md) section.
 
-## Node Quick Links
+## Quick Links
 
 <div class="docs-card-container">
   <div class="row row-cols-1 row-cols-md-2a g-4">
@@ -71,7 +71,7 @@ find additional resources for node operation in the [External Resources](../comm
     <div class="col">
       <div class="card-no-border card-body h-100 d-flex flex-column">
         <div class="card-body">
-          <h2 class="card-title">Node Operator</h2>
+          <h2 class="card-title">Validators and VFNs</h2>
           <p class="card-text">
             A comprehensive guide to deploying nodes, staking operations and participate in consensus.
           </p>
@@ -119,7 +119,7 @@ find additional resources for node operation in the [External Resources](../comm
     <div class="col">
       <div class="card-no-border card-body h-100 d-flex flex-column">
         <div class="card-body">
-          <h2 class="card-title">Public Fullnode</h2>
+          <h2 class="card-title">Public Fullnodes (PFNs)</h2>
           <p class="card-text">
             A section with detailed, step-by-step instructions on everything related to Aptos PFNs.
           </p>
@@ -127,46 +127,43 @@ find additional resources for node operation in the [External Resources](../comm
         <div class="list-group list-group-flush">
           <a href="/nodes/full-node/public-fullnode" class="list-group-item">
             <div class="d-flex w-100 justify-content-between">
-              <h4 class="mb-1">Public fullnode</h4>
+              <h4 class="mb-1">Deploy a PFN</h4>
             </div>
-            <small>Follow this section to install a public fullnode.</small>
+            <small>Follow this section to deploy a PFN.</small>
           </a>
           <a href="/indexer/legacy/indexer-fullnode" class="list-group-item">
             <div class="d-flex w-100 justify-content-between">
-              <h4 class="mb-1">Indexer fullnode</h4>
+              <h4 class="mb-1">Indexer PFN</h4>
             </div>
             <small
-              >Describes how to run an indexer fullnode on the Aptos network. </small>
+              >Describes how to run an indexer PFN on the Aptos network. </small>
           </a>
+          <div class="card-body">
+          <h2 class="card-title">Common Operations</h2>
+          </div>
           <a href="/nodes/local-testnet/local-testnet-index" class="list-group-item">
             <div class="d-flex w-100 justify-content-between">
-              <h4 class="mb-1">Local testnet</h4>
+              <h4 class="mb-1">Local development testnet</h4>
             </div>
-            <small>Run a local testnet with a validator node.</small>
-          </a>
-          <a href="/nodes/full-node/fullnode-network-connections" class="list-group-item">
-            <div class="d-flex w-100 justify-content-between">
-              <h4 class="mb-1">Fullnode network connections</h4>
-            </div>
-            <small>Describes in detail how to configure your node's network connections.</small>
-          </a>
-          <a href="/nodes/full-node/network-identity-fullnode" class="list-group-item">
-            <div class="d-flex w-100 justify-content-between">
-              <h4 class="mb-1">Network identity for PFNs</h4>
-            </div>
-            <small>Create a static network identity for your fullnode.</small>
+            <small>Run a local testnet for development (including validator nodes).</small>
           </a>
           <a href="/nodes/full-node/update-fullnode-with-new-devnet-releases" class="list-group-item">
             <div class="d-flex w-100 justify-content-between">
-              <h4 class="mb-1">Update fullnode</h4>
+              <h4 class="mb-1">Upgrade a node</h4>
             </div>
-            <small>When devnet is wiped and updated with newer versions, follow this document to update your fullnode.</small>
+            <small>Upgrade your node with new releases.</small>
           </a>
           <a href="/nodes/full-node/bootstrap-fullnode" class="list-group-item">
             <div class="d-flex w-100 justify-content-between">
-              <h4 class="mb-1">Bootstrap a new fullnode</h4>
+              <h4 class="mb-1">Bootstrap from a snapshot</h4>
             </div>
-            <small>Use data restore to bootstrap a new fullnode.</small>
+            <small>Use a snapshot to bootstrap a new node.</small>
+          </a>
+          <a href="/nodes/full-node/bootstrap-fullnode" class="list-group-item">
+            <div class="d-flex w-100 justify-content-between">
+              <h4 class="mb-1">Bootstrap from a backup</h4>
+            </div>
+            <small>Use data restore to bootstrap a new node.</small>
           </a>
         </div>
       </div>

--- a/docs/reference/telemetry.md
+++ b/docs/reference/telemetry.md
@@ -2,77 +2,82 @@
 title: "Telemetry"
 ---
 
-When you operate a node on an Aptos network, your node can be set to send telemetry data to Aptos Labs. You can disable telemetry at any point. If telemetry remains enabled, Aptos node binary will send telemetry data in the background.
+When you run a node on an Aptos network, your node will send telemetry data to Aptos Labs. All node types
+(e.g., validators, VFNs and PFNs) send telemetry data. This also occurs for other binaries (e.g., the Aptos CLI).
+If you would prefer not to send telemetry, you can disable telemetry using the instructions below.
 
-The Aptos node binary running on your node collects telemetry data such as software version, operating system information and the IP address of your node. This telemetry data is used to enhance the decentralization of the network.
-
-:::tip No personal information is collected
-The Aptos node binary does **not** collect personal information such as usernames or email addresses.
+:::danger No personal information is collected
+The Aptos node binary does **not** collect any personal information, such as usernames or email addresses.
+It only collects relevant node telemetry, such as software version, node metrics, operating system information and the IP
+address of your node. This data is used to enhance the decentralization and performance of the network.
 :::
 
-## Metrics collected
+## Node telemetry
 
-### Core metrics
+The list below shows the categories of information collected by Aptos node telemetry:
 
-- Core metrics: [https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-telemetry/src/core_metrics.rs#L14-L29](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-telemetry/src/core_metrics.rs#L14-L29).
+- **Core metrics:** Core metrics are those emitted by the core components of the `aptos-node` binary. These include,
+  state sync, consensus, mempool and storage. You can see the full list of core metrics,
+  [here](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-telemetry/src/core_metrics.rs#L14-L29).
 
-### Node information
+- **Build information**: Rust build information, including the versions of Rust, cargo, the target architecture and
+  the build tag are also collected. You can see the full list of build information, [here](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-build-info/src/lib.rs#L8-L20).
 
-The public IP address of the node and core metrics, including node type, synced version and number of network connections.
+- **System information**: System information is also collected by node telemetry. This includes resource information
+  (e.g., CPU, RAM, disk and network specifications) as well as operating system information. You can see the full list of
+  system information, [here](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-telemetry/src/system_information.rs#L14-L32).
 
-- **Node configuration as a mapping of string key to JSON map**: [https://github.com/aptos-labs/aptos-core/blob/main/config/src/config/mod.rs#L63-L97](https://github.com/aptos-labs/aptos-core/blob/main/config/src/config/mod.rs#L63-L97).
+- **Network metrics:**: Network metrics are also collected by node telemetry. These include network information such as
+  the number of connected peers, the number of inbound and outbound messages, and the size of messages sent and received.
+  You can see the full list of network metrics, [here](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-telemetry/src/network_metrics.rs#L12-L17).
 
-### CLI telemetry
+- **Prometheus metrics**: Prometheus metrics are also collected by node telemetry. These include runtime metrics
+  for all the components of the `aptos-node` binary. You can see the full list of Prometheus metrics by visiting the
+  metrics endpoint on your node using the [node inspection service](../nodes/measure/node-inspection-service.md).
 
-The commands and subcommands run by the Aptos CLI tool.
+- **Node logs**: Logs of warn-level and higher are also collected by node telemetry. These are used to monitor the
+  health of the network. You can identify these logs by filtering the logs for the `aptos-node` binary, locally.
 
-- **CLI metrics**: [https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-telemetry/src/cli_metrics.rs#L12-L15](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-telemetry/src/cli_metrics.rs#L12-L15).
-- **Build information**: [https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-build-info/src/lib.rs#L8-L20](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-build-info/src/lib.rs#L8-L20).
+## CLI telemetry
 
-### Network metrics
+The Aptos CLI tool also collects telemetry data. The list below shows the categories of information collected by
+CLI telemetry:
 
-- **Network metrics**: [https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-telemetry/src/network_metrics.rs#L12-L17](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-telemetry/src/network_metrics.rs#L12-L17).
+- **Command metrics**: Command metrics are those emitted by the CLI when a command is executed. These
+  include the command itself, the latency of the command, and the success or failure of the command. You can see
+  the full list of CLI metrics,
+  [here](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-telemetry/src/cli_metrics.rs#L12-L15).
 
-### Build information
-
-Rust build information including the versions of Rust, cargo, build target architecture and the build tag.
-
-- **Build information**: [https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-build-info/src/lib.rs#L8-L20](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-build-info/src/lib.rs#L8-L20)
-
-### System information
-
-System information including operating system information (including versions), hardware information and resource utilization (including CPU, memory and disk).
-
-- **System information**: [https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-telemetry/src/system_information.rs#L14-L32](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-telemetry/src/system_information.rs#L14-L32).
-
-### Others
-
-- **Metrics**: All the [Prometheus](https://prometheus.io/) metrics that are collected within the node.
-- **Logs**: Logs of warn-level and higher level, with the ability to collect up to debug logs.
+- **Build information**: Rust build information, including the versions of Rust, cargo, the target architecture and
+  the build tag are also collected for the CLI. You can see the full list of build information, [here](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-build-info/src/lib.rs#L8-L20).
 
 ## Disabling telemetry
 
-On macOS and Linux, you can set the following environment variables to control the metrics sent by your node. For example, to disable all telemetry, set the `APTOS_DISABLE_TELEMETRY` environment variable to `true` as shown below:
+On macOS and Linux, you can set the `APTOS_DISABLE_TELEMETRY` environment variable to disable the metrics sent by
+both the Aptos node and the Aptos CLI tool. To disable all telemetry, set `APTOS_DISABLE_TELEMETRY` environment to `true`:
 
 ```bash
 export APTOS_DISABLE_TELEMETRY=true
 ```
 
-The above example only disables telemetry for a single session in the current terminal where you ran the above command. To disable it permanently on your node, include it in your startup profile, as below:
+The above command only disables telemetry for a single session in the current terminal where you run the command.
+To disable it permanently across all terminals and Aptos binary invocations, include it in your startup profile.
+For example:
 
 ```bash
 echo "export APTOS_DISABLE_TELEMETRY=true" >> ~/.profile
 source ~/.profile
 ```
 
-:::tip All telemetry is ON by default.
-All the below variables are set by default to `false`, i.e., sending of these telemetry metrics is enabled. Set them to `true` to disable telemetry.
-:::
+## Configuring telemetry
 
-- `APTOS_DISABLE_TELEMETRY`: This disables all telemetry emission from the node including sending to the GA4 service.
-- `APTOS_FORCE_ENABLE_TELEMETRY`: This overrides the chain ID check and forces the node to send telemetry regardless of whether remote service accepts or not.
-- `APTOS_DISABLE_TELEMETRY_PUSH_METRICS`: This disables sending the [Prometheus](https://prometheus.io/) metrics.
-- `APTOS_DISABLE_TELEMETRY_PUSH_LOGS`: This disables sending the logs.
-- `APTOS_DISABLE_TELEMETRY_PUSH_EVENTS`: This disables sending the custom events.
+You can also configure telemetry to disable specific telemetry metrics and collections. The environment variable
+list below shows the variables you can set to configure telemetry for Aptos nodes and the CLI:
+
+- `APTOS_DISABLE_TELEMETRY`: This disables all telemetry emission, including sending telemetry to the Google Analytics service (GA4).
+- `APTOS_FORCE_ENABLE_TELEMETRY`: This overrides the chain ID check and forces the Aptos node to send telemetry regardless of whether the remote service accepts it or not.
+- `APTOS_DISABLE_TELEMETRY_PUSH_METRICS`: This disables sending [Prometheus](https://prometheus.io/) metrics.
+- `APTOS_DISABLE_TELEMETRY_PUSH_LOGS`: This disables sending logs.
+- `APTOS_DISABLE_TELEMETRY_PUSH_EVENTS`: This disables sending custom events.
 - `APTOS_DISABLE_LOG_ENV_POLLING`: This disables the dynamic ability to send verbose logs.
-- `APTOS_DISABLE_PROMETHEUS_NODE_METRICS`: This disables sending the node resource metrics such as system CPU, memory, etc.
+- `APTOS_DISABLE_PROMETHEUS_NODE_METRICS`: This disables sending the Aptos node resource metrics such as system CPU, memory, etc.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -154,7 +154,7 @@ const themeConfig: Preset.ThemeConfig = {
           },
           {
             label: "Configure a Node",
-            to: "nodes/identity-and-configuration",
+            to: "nodes/configure/configure-index",
           },
           {
             label: "Monitor a Node",

--- a/src/components/sidebars.ts
+++ b/src/components/sidebars.ts
@@ -584,17 +584,17 @@ const sidebars: SidebarsConfig = {
       label: "Configure a Node",
       collapsible: true,
       collapsed: true,
-      link: { type: "doc", id: "nodes/identity-and-configuration" },
+      link: { type: "doc", id: "nodes/configure/index" },
       items: [
-        "reference/telemetry",
         "guides/state-sync",
         "guides/data-pruning",
+        "reference/telemetry",
         {
           type: "category",
-          label: "Node Files",
+          label: "Locating Node Files",
           collapsible: true,
           collapsed: true,
-          link: { type: "doc", id: "nodes/node-files-all-networks/node-files" },
+          link: { type: "doc", id: "nodes/node-files-all-networks/index" },
           items: [
             "nodes/node-files-all-networks/node-files",
             "nodes/node-files-all-networks/node-files-testnet",


### PR DESCRIPTION
### Description

This PR builds on https://github.com/aptos-labs/developer-docs/pull/171 and continues to clean up the node docs. In this PR, we:
- Clean up the node configuration section.
- Move the configuration and identity page to the validator tab (the content is validator specific and should not be here).
- Take a pass over all configuration documents. There was still a bunch of out-of-date/incorrect information in these pages.

I will look to clean up the validator section, next. Will follow up in a separate PR.

### Checklist
- [x] Do all Lints pass?
- [x] Have you ran `pnpm spellcheck`?
- [x] Have you ran `pnpm fmt`?
- [x] Have you ran `pnpm lint`?
