### PR TITLE
[ts-sdk] Add redirects for the new ts-sdk

### DIFF
--- a/apps/docusaurus/docusaurus.config.ts
+++ b/apps/docusaurus/docusaurus.config.ts
@@ -390,6 +390,38 @@ const config: Config = {
             from: "/sdks/new-ts-sdk",
             to: "/sdks/ts-sdk",
           },
+          {
+            from: "/sdks/new-ts-sdk/account",
+            to: "/sdks/ts-sdk/account",
+          },
+          {
+            from: "/sdks/new-ts-sdk/fetch-data-from-chain",
+            to: "/sdks/ts-sdk/fetch-data-from-chain",
+          },
+          {
+            from: "/sdks/new-ts-sdk/http-client",
+            to: "/sdks/ts-sdk/http-client",
+          },
+          {
+            from: "/sdks/new-ts-sdk/migration-guide",
+            to: "/sdks/ts-sdk/migration-guide",
+          },
+          {
+            from: "/sdks/new-ts-sdk/move-types",
+            to: "/sdks/ts-sdk/move-types",
+          },
+          {
+            from: "/sdks/new-ts-sdk/sdk-configuration",
+            to: "/sdks/ts-sdk/sdk-configuration",
+          },
+          {
+            from: "/sdks/new-ts-sdk/transaction-builder",
+            to: "/sdks/ts-sdk/transaction-builder",
+          },
+          {
+            from: "/sdks/new-ts-sdk/typescript",
+            to: "/sdks/ts-sdk/typescript",
+          },
         ],
         // Create redirects for all the move pages
         createRedirects(existingPath) {


### PR DESCRIPTION
I purposely did not make redirects for the legacy ts-sdk, as those docs should be eventually removed

### Description

### Checklist

- [x] Do all Lints pass?
- [] Have you ran `pnpm spellcheck`?
- [x] Have you ran `pnpm fmt`?
- [x] Have you ran `pnpm lint`?
