### PR TITLE
Fix nextra - Focused on Search / Indexing

### DIFF
--- a/apps/nextra/package.json
+++ b/apps/nextra/package.json
@@ -11,7 +11,7 @@
     "dev": "next -p 3030",
     "prebuild": "node nextra-remote-filepaths/fetch.js",
     "predev": "pnpm prebuild",
-    "start": "next start",
+    "start": "next start -p 3030",
     "types:check": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/nextra/package.json
+++ b/apps/nextra/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "clean": "rimraf .next .turbo",
     "debug": "NODE_OPTIONS='--inspect' next dev",
-    "dev": "next",
+    "dev": "next -p 3030",
     "prebuild": "node nextra-remote-filepaths/fetch.js",
     "predev": "pnpm prebuild",
     "start": "next start",

--- a/apps/nextra/pages/en/_meta.ts
+++ b/apps/nextra/pages/en/_meta.ts
@@ -79,11 +79,6 @@ export default {
       }
     }
   },
-  docs: {
-    type: 'page',
-    title: 'Docs',
-    display: 'hidden'
-  },
   nextra_link: {
     type: 'page',
     title: 'Nextra ↗',

--- a/apps/nextra/pages/en/build/advanced_guides/index.mdx
+++ b/apps/nextra/pages/en/build/advanced_guides/index.mdx
@@ -1,1 +1,3 @@
 # Advanced Guides
+
+TODO fill in advanced guides

--- a/apps/nextra/pages/en/build/apis/index.mdx
+++ b/apps/nextra/pages/en/build/apis/index.mdx
@@ -1,1 +1,3 @@
 # APIs
+
+TODO fill in APIs

--- a/apps/nextra/pages/en/build/cli/index.mdx
+++ b/apps/nextra/pages/en/build/cli/index.mdx
@@ -1,1 +1,3 @@
 # CLI
+
+TODO fill in CLIs

--- a/apps/nextra/pages/en/build/indexer/index.mdx
+++ b/apps/nextra/pages/en/build/indexer/index.mdx
@@ -1,1 +1,3 @@
 # Indexer
+
+TODO fill in Indexer

--- a/apps/nextra/pages/en/build/quick_start/index.mdx
+++ b/apps/nextra/pages/en/build/quick_start/index.mdx
@@ -1,1 +1,3 @@
 # Quick Start
+
+TODO fill in Quick Start

--- a/apps/nextra/pages/en/build/sdks/index.mdx
+++ b/apps/nextra/pages/en/build/sdks/index.mdx
@@ -1,1 +1,3 @@
 # SDKs
+
+TODO fill in SDKs

--- a/apps/nextra/pages/en/build/smart_contracts/index.mdx
+++ b/apps/nextra/pages/en/build/smart_contracts/index.mdx
@@ -1,1 +1,3 @@
 # Smart Contracts
+
+TODO fill in Smart Contracts

--- a/apps/nextra/pages/en/docs/setup/_meta.ts
+++ b/apps/nextra/pages/en/docs/setup/_meta.ts
@@ -7,4 +7,5 @@ export default {
   'i18n': 'i18n',
   'maintenance': 'Maintenance',
   'deployment': 'Deployment',
+  'troubleshooting': 'Troubleshooting',
 }

--- a/apps/nextra/pages/en/docs/setup/troubleshooting.mdx
+++ b/apps/nextra/pages/en/docs/setup/troubleshooting.mdx
@@ -1,0 +1,99 @@
+---
+title: Troubleshooting
+---
+
+import { FileTree, Callout } from 'nextra/components'
+
+# Troubleshooting
+
+Unfortunately, there are some issues with Nextra. The goal of this document is to provide guidance on how one can fix these issues.
+Below I'll highlight some problems you may encounter and how you may address them.
+
+## Search
+
+<Callout type="info">
+Note: It is recommended that you do NOT use search when running `pnpm dev` for the Nextra docs site.
+Most of the issues related to Nextra search occur when running `pnpm dev` exclusively. 
+You may find that it miraculously works when you deploy your site
+or test it locally via `pnpm build && pnpm start`. See below for why.
+</Callout>
+
+### How Nextra search works
+
+Nextra v3 relies on [FlexSearch](https://github.com/nextapps-de/flexsearch), an in-memory search library, unlike other 
+documentation templates like Docusaurus which rely on Algolia as a hosted search service. 
+
+When a Nextra docs project is compiled, the `NextraSearchPlugin` (a webpack plugin in Nextra) goes through each file,
+collects the relevent frontmatter and data for each page, adds it to a JSON file `nextra-data-<LOCALE>.json`, 
+keyed by locale (e.g., `nextra-data-en.json`), and adds that JSON file to the `.next` build output folder. 
+
+See below for where you can find that file.
+
+<FileTree>
+  <FileTree.Folder name=".next" defaultOpen>
+    <FileTree.Folder name="static" defaultOpen>
+      <FileTree.Folder name="chunks" defaultOpen>
+        <FileTree.Folder name="pages" defaultOpen>
+          <FileTree.File name="nextra-data-en.json" active />
+        </FileTree.Folder>
+      </FileTree.Folder>
+    </FileTree.Folder>
+  </FileTree.Folder>
+  <FileTree.Folder name="pages" defaultOpen>
+    <FileTree.File name="_meta.ts" />
+    <FileTree.File name="index.mdx" />
+  </FileTree.Folder>
+</FileTree>
+
+When users then query for a certain keyword, FlexSearch combs through the indexes to surface the relevant content and pages.
+
+### Problems
+
+#### Content does not appear in search results
+
+When running `pnpm dev` and searching for content, you may notice that you can find content for the current page 
+(or descendents of the current page), but not for other pages.
+
+Unfortunately, Nextra often does not compile indexes correctly when using `pnpm dev`. When running `pnpm dev`, the
+`/_next/static/chunks/nextra-data-en.json` only contains the relevant material for the current page.
+
+#### Error: Rendered more hooks than during the previous render.
+
+This may occur when running `pnpm dev` and selecting the search field.
+
+If you inspect element, this error is typically accompanied with a 
+`404 (Not Found)` for `/_next/static/chunks/nextra-data-en.json`.
+The reason for this error is similar to the `Content does not appear in Search results` 
+error mentioned above. 
+
+When running `pnpm dev`, Nextra's `NextraSearchPlugin` goes to the current page 
+(often `index.mdx` if you're on `localhost:3030/en`) and reads the frontmatter on `index.mdx`. 
+
+You'll notice that there's a `searchable: false` located at the top of the index file, like so:
+
+```mdx
+---
+searchable: false
+---
+```
+
+This causes the `NextraSearchPlugin` to skip the creation of the `nextra-data-en.json`, thus causing the `404 (Not found)`.
+
+#### Caching
+
+When searching, you may sometimes notice that the search results are not up to date or missing recently added changes. 
+This is often because the `nextra-data-en.json` file has been cached and not updated to the latest.
+
+##### Solution
+
+To address this issue, inspect element on the page, and navigate to the `Network` tab. 
+Then click on the `Disable Cache` checkbox right below the `Network` tab
+and refresh the page. 
+
+Alternatively open a new `Incognito` window and navigate to the page. 
+
+### Solutions
+
+Most of the problems mentioned above can be fixed by running `pnpm build && pnpm start`. From this command, the indexes should be compiled for all pages.
+
+In some instances, you may want to also disable caching and force refresh the page (for more info see the `caching` section).

--- a/apps/nextra/pages/en/network/blockchain/index.mdx
+++ b/apps/nextra/pages/en/network/blockchain/index.mdx
@@ -1,1 +1,3 @@
 # Blockchain
+
+TODO fill in Blockchain

--- a/apps/nextra/pages/en/network/glossary/index.mdx
+++ b/apps/nextra/pages/en/network/glossary/index.mdx
@@ -1,1 +1,3 @@
 # Glossary
+
+TODO fill in Glossary

--- a/apps/nextra/pages/en/network/nodes/index.mdx
+++ b/apps/nextra/pages/en/network/nodes/index.mdx
@@ -1,1 +1,3 @@
 # Nodes
+
+TODO fill in Nodes

--- a/apps/nextra/pages/en/network/releases/index.mdx
+++ b/apps/nextra/pages/en/network/releases/index.mdx
@@ -1,1 +1,3 @@
 # Releases
+
+TODO fill in Releases


### PR DESCRIPTION
### Description

After digging into Nextra Search more, I discovered that Search does not work properly on `pnpm dev`, but does on `pnpm build && pnpm start` (in other words, works in production). I followed up by investigating the problem and discovered there was an issue in the `NextraSearchPlugin` in the base `Nextra` repo, and reported the issue here: https://github.com/shuding/nextra/issues/2763. Thankfully the maintainer responded and mentioned that he was going to prioritize it for the next alpha release. In the meantime, I've added a troubleshooting guide for those that run into Search related issues during development. 

I also changed the default port to `3030` to avoid any conflicts with the docusaurus port

### Checklist

- [x] Do all Lints pass?
- [x] Have you ran `pnpm spellcheck`?
- [x] Have you ran `pnpm fmt`?
- [x] Have you ran `pnpm lint`?
