### PR TITLE
Fix:  Enter Correct Directory After Clone

### DIFF
--- a/apps/docusaurus/docs/tutorials/first-fungible-asset.md
+++ b/apps/docusaurus/docs/tutorials/first-fungible-asset.md
@@ -43,7 +43,7 @@ git clone https://github.com/aptos-labs/aptos-ts-sdk.git
 Navigate to the TypeScript SDK directory:
 
 ```bash
-cd ~/aptos-ts-sdk/examples/typescript
+cd aptos-ts-sdk/examples/typescript
 ```
 
 Install the necessary dependencies:

--- a/apps/docusaurus/docs/tutorials/your-first-nft.md
+++ b/apps/docusaurus/docs/tutorials/your-first-nft.md
@@ -70,7 +70,7 @@ git clone https://github.com/aptos-labs/aptos-core.git
 Navigate to the Python SDK directory:
 
 ```bash
-cd ~/aptos-core/ecosystem/python/sdk
+cd aptos-core/ecosystem/python/sdk
 ```
 
 Install the necessary dependencies:


### PR DESCRIPTION
### Description

When executing `git clone`, it should create a folder in the current directory, so there's no need to cd into the home directory.

```
git clone https://github.com/aptos-labs/aptos-core.git 
```

```bash
cd ~/aptos-core/ecosystem/python/sdk
```

So, it should use the current directory.

```bash
cd ~/aptos-core/ecosystem/python/sdk => cd aptos-core/ecosystem/python/sdk
```
