### PR TITLE
[ts-sdk] Fix parameter error in ts-sdk example 

### DIFF
--- a/apps/docusaurus/docs/sdks/ts-sdk/index.md
+++ b/apps/docusaurus/docs/sdks/ts-sdk/index.md
@@ -102,7 +102,7 @@ const pendingTransaction = await aptos.signAndSubmitTransaction({
 const alice: Account = Account.generate();
 
 // create the account on chain
-await aptos.fundAccount({ accountAddress: alice.accountAddress, amount: 1000 });
+await aptos.fundAccount({ accountAddress: alice.accountAddress, amount: 100000000 });
 
 // submit transaction to transfer APT coin from Alice to Bob
 const bobAddress = "0xb0b";
@@ -110,7 +110,7 @@ const bobAddress = "0xb0b";
 const transaction = await aptos.transaction.build.simple({
   sender: alice.accountAddress,
   data: {
-    function: "0x1::coin::transfer",
+    function: "0x1::aptos_account::transfer_coins",
     typeArguments: ["0x1::aptos_coin::AptosCoin"],
     functionArguments: [bobAddress, 100],
   },


### PR DESCRIPTION
### Description


If the requested amount of funds at the beginning is too low, it will result in subsequent transactions by the user failing.

should: `amount: 100000000`

```
await aptos.fundAccount({ accountAddress: alice.accountAddress, amount: 1000 });
```


`coin tranfer` cannot send the coin to a recipient without a CoinStore.
We need to use `0x1::aptos_account::transfer_coins`
```
function: "0x1::coin::transfer",
typeArguments: ["0x1::aptos_coin::AptosCoin"],
functionArguments: [bobAddress, 100],
```

### Checklist

- Do all Lints pass?
  - [] Have you ran `pnpm spellcheck`?
  - [] Have you ran `pnpm fmt`?
  - [] Have you ran `pnpm lint`?
