### PR TITLE
[docs] Fix entry fun return value

### DIFF
--- a/apps/docusaurus/docs/move/book/functions.md
+++ b/apps/docusaurus/docs/move/book/functions.md
@@ -128,7 +128,7 @@ For example:
 ```move
 address 0x42 {
 module m {
-    public entry fun foo(): u64 { 0 }
+    public entry fun foo(): {  }
     fun calls_foo(): u64 { foo() } // valid!
 }
 


### PR DESCRIPTION
### Description

The entry function cannot have a return value.

### Checklist

- Do all Lints pass?
  - [] Have you ran `pnpm spellcheck`?
  - [] Have you ran `pnpm fmt`?
  - [] Have you ran `pnpm lint`?
