### PR TITLE
[CLI] Handle when packaging / distutils is absent in CLI installation script

### DIFF
--- a/apps/docusaurus/docs/guides/keyless-accounts.md
+++ b/apps/docusaurus/docs/guides/keyless-accounts.md
@@ -144,7 +144,10 @@ export const storeEphemeralKeyPair = (
 
   // Store the new ephemeral key pair in localStorage
   accounts[ephemeralKeyPair.nonce] = ephemeralKeyPair;
-  localStorage.setItem("ephemeral-key-pairs", encodeEphemeralKeyPairs(accounts));
+  localStorage.setItem(
+    "ephemeral-key-pairs",
+    encodeEphemeralKeyPairs(accounts),
+  );
 };
 
 /**

--- a/apps/docusaurus/docs/tools/aptos-cli/install-cli/automated-install.md
+++ b/apps/docusaurus/docs/tools/aptos-cli/install-cli/automated-install.md
@@ -41,8 +41,13 @@ wget -qO- "https://aptos.dev/scripts/install_cli.py" | python3
 ```
 
 :::tip
-If you receive an error `ModuleNotFoundError: No module named packaging`
-You need to install `packaging` first
+If you see this message:
+
+```
+Couldn't find distutils or packaging. We cannot check the current version of the CLI. We will install the latest version.
+```
+
+Consider installing `packaging` first:
 
 ```Shell
 pip3 install packaging


### PR DESCRIPTION
### Description
This way people won't run into issues with the missing package, it'll just work. Generally when people are running this script they're installing for the first time anyway so there is no big problem if the check for the current version fails.

### Test Plan
On a Linux machine:
```
python install_cli.py
```

I ran it as normal and it worked. I then made the first two blocks throw an ImportError and it worked as intended too.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
