### PR TITLE
[sdks] Move SDKs all to folders

### DIFF
--- a/apps/docusaurus/docs/concepts/txns-states.md
+++ b/apps/docusaurus/docs/concepts/txns-states.md
@@ -62,7 +62,7 @@ Within a given transaction, the two most common types of payloads include:
 - An entry point
 - [A script (payload)](../move/move-on-aptos/scripts/index.md)
 
-Currently, the SDKs [Python](/sdks/python-sdk.md) and [Typescript](/sdks/ts-sdk/index.md) support both. This guide points out many of those entry points, such as `coin::transfer` and `aptos_account::create_account`.
+Currently, the SDKs [Python](/sdks/python-sdk/index.md) and [Typescript](/sdks/ts-sdk/index.md) support both. This guide points out many of those entry points, such as `coin::transfer` and `aptos_account::create_account`.
 
 All operations on the Aptos blockchain should be available via entry point calls. While one could submit multiple transactions calling entry points in series, many such operations may benefit from being called atomically from a single transaction. A script payload transaction can call any entry point or public function defined within any module.
 

--- a/apps/docusaurus/docs/guides/account-management/key-rotation.md
+++ b/apps/docusaurus/docs/guides/account-management/key-rotation.md
@@ -16,7 +16,7 @@ Here are the installation links for the SDKs we will cover in this example:
 
 - [Aptos CLI](../../tools/aptos-cli)
 - [Typescript SDK](/sdks/ts-sdk/index.md)
-- [Python SDK](../../sdks/python-sdk)
+- [Python SDK](../../sdks/python-sdk/index.md)
 
 :::warning
 Some of the following examples use private keys. Do not share your private keys with anyone.

--- a/apps/docusaurus/docs/guides/system-integrators-guide.md
+++ b/apps/docusaurus/docs/guides/system-integrators-guide.md
@@ -83,8 +83,8 @@ Either of these methods will expose a [REST API service](../apis/fullnode-rest-a
 Aptos currently provides three SDKs:
 
 1. [Typescript](../sdks/ts-sdk/index.md)
-2. [Python](../sdks/python-sdk.md)
-3. [Rust](../sdks/rust-sdk.md)
+2. [Python](../sdks/python-sdk/index.md)
+3. [Rust](../sdks/rust-sdk/index.md)
 
 Almost all developers will benefit from exploring the CLI. [Using the CLI](../tools/aptos-cli/use-cli/use-aptos-cli.md) demonstrates how the CLI can be used to which includes creating accounts, transferring coins, and publishing modules.
 

--- a/apps/docusaurus/docs/sdks/index.md
+++ b/apps/docusaurus/docs/sdks/index.md
@@ -10,10 +10,10 @@ Use these Aptos software development kits (SDKs), in combination with the [Aptos
 
 - ### [TypeScript SDK](ts-sdk/index.md)
 
-- ### [Python SDK](python-sdk.md)
+- ### [Python SDK](python-sdk/index.md)
 
-- ### [Rust SDK](rust-sdk.md)
+- ### [Rust SDK](rust-sdk/index.md)
 
-- ### [Unity SDK](unity-sdk.md)
+- ### [Unity SDK](unity-sdk/index.md)
 
 To get started, [develop with the Aptos SDKs](../tutorials/index.md) following our tutorials.

--- a/apps/docusaurus/docs/sdks/legacy-ts-sdk/index.md
+++ b/apps/docusaurus/docs/sdks/legacy-ts-sdk/index.md
@@ -10,7 +10,7 @@ hidden: false
 This documentation is for the **legacy TypeScript SDK**, aka `aptos`. For a more robust and better SDK support, we recommend upgrading to the **new TypeScript SDK** [@aptos-labs/ts-sdk](https://github.com/aptos-labs/aptos-ts-sdk). Take a look at the [documentation](../ts-sdk/index.md) and the [migration guide](../ts-sdk/migration-guide.md)
 :::
 
-Aptos provides a fully supported TypeScript SDK with the source code in the [Aptos-core GitHub](https://github.com/aptos-labs/aptos-core/tree/main/ecosystem/typescript/sdk) repository. Much of the functionality of the TypeScript SDK can be found in the [Rust](../rust-sdk.md) and [Python](../python-sdk.md) SDKs. Nevertheless, Aptos strongly encourages you to use the TypeScript SDK for app development whenever possible.
+Aptos provides a fully supported TypeScript SDK with the source code in the [Aptos-core GitHub](https://github.com/aptos-labs/aptos-core/tree/main/ecosystem/typescript/sdk) repository.
 
 ## Installing the TypeScript SDK
 

--- a/apps/docusaurus/docs/sdks/python-sdk/index.md
+++ b/apps/docusaurus/docs/sdks/python-sdk/index.md
@@ -4,7 +4,7 @@ title: "Python SDK"
 
 # Aptos Python SDK
 
-Aptos provides a lightly maintained official Python SDK. It is available on [PyPi](https://pypi.org/project/aptos-sdk/) with the source code in the [Aptos-core GitHub repository](https://github.com/aptos-labs/aptos-core/tree/main/ecosystem/python/sdk). Much of the functionality of the Python SDK mirrors the [Typescript SDK](ts-sdk/index.md). The primary purpose of the Python SDK is to help Python developers to quickly become familiar with Aptos and as an accompaniment to Aptos tutorials.
+Aptos provides a lightly maintained official Python SDK. It is available on [PyPi](https://pypi.org/project/aptos-sdk/) with the source code in the [Aptos-core GitHub repository](https://github.com/aptos-labs/aptos-core/tree/main/ecosystem/python/sdk). Much of the functionality of the Python SDK mirrors the [Typescript SDK](../ts-sdk/index.md). The primary purpose of the Python SDK is to help Python developers to quickly become familiar with Aptos and as an accompaniment to Aptos tutorials.
 
 ## Installing Python SDK
 
@@ -40,4 +40,4 @@ cp -r /path/to/aptos-core/ecosystem/python/sdk/aptos-sdk aptos-sdk
 
 ## Using the Python SDK
 
-See the [Developer Tutorials](../tutorials/index.md) for code examples showing how to use the Python SDK.
+See the [Developer Tutorials](../../tutorials/index.md) for code examples showing how to use the Python SDK.

--- a/apps/docusaurus/docs/sdks/rust-sdk/index.md
+++ b/apps/docusaurus/docs/sdks/rust-sdk/index.md
@@ -28,4 +28,4 @@ The source code for the official Rust SDK is available in the [aptos-core GitHub
 
 ## Using Rust SDK
 
-See the [Developer Tutorials](../tutorials/index.md) for code examples showing how to use the Rust SDK.
+See the [Developer Tutorials](../../tutorials/index.md) for code examples showing how to use the Rust SDK.

--- a/apps/docusaurus/docs/sdks/unity-sdk/index.md
+++ b/apps/docusaurus/docs/sdks/unity-sdk/index.md
@@ -4,7 +4,7 @@ title: "Unity SDK"
 
 # Aptos Unity SDK
 
-The [Aptos Unity SDK](https://github.com/aptos-labs/Aptos-Unity-SDK) is a .NET implementation of the [Aptos SDK](./index.md), compatible with .NET Standard 2.0 and .NET 4.x for Unity. The goal of this SDK is to provide a set of tools for developers to build multi-platform applications (mobile, desktop, web, VR) using the Unity game engine and the Aptos blockchain infrastructure.
+The [Aptos Unity SDK](https://github.com/aptos-labs/Aptos-Unity-SDK) is a .NET implementation of the [Aptos SDK](../index.md), compatible with .NET Standard 2.0 and .NET 4.x for Unity. The goal of this SDK is to provide a set of tools for developers to build multi-platform applications (mobile, desktop, web, VR) using the Unity game engine and the Aptos blockchain infrastructure.
 
 See the post [Aptos Labs brings Web3 to Gaming with its new SDK for Unity developers](https://medium.com/aptoslabs/aptos-labs-brings-web3-to-gaming-with-its-new-sdk-for-unity-developers-e6544bdf9ba9) and the [Technical details](https://github.com/aptos-labs/Aptos-Unity-SDK#technical-details) section of the Unity SDK README for all the features offered to game developers by the Aptos Unity SDK.
 

--- a/apps/docusaurus/docs/standards/multisig-managed-fungible-asset.md
+++ b/apps/docusaurus/docs/standards/multisig-managed-fungible-asset.md
@@ -12,7 +12,7 @@ This tutorial introduces a practical use case that combines Aptos framework mult
 
 This tutorial was created for the [TypeScript SDK](../sdks/legacy-ts-sdk/index.md).
 
-Other developers are invited to add support for the [Python SDK](../sdks/python-sdk.md), [Rust SDK](../sdks/rust-sdk.md), and [Unity SDK](../sdks/unity-sdk.md)!
+Other developers are invited to add support for the [Python SDK](../sdks/python-sdk/index.md), [Rust SDK](../sdks/rust-sdk/index.md), and [Unity SDK](../sdks/unity-sdk/index.md)!
 
 ## Step 2: Publish the module
 

--- a/apps/docusaurus/docs/tutorials/first-coin.md
+++ b/apps/docusaurus/docs/tutorials/first-coin.md
@@ -15,8 +15,8 @@ This tutorial introduces how you can compile, deploy, and mint your own coin, na
 Install your preferred SDK from the below list:
 
 - [TypeScript SDK](../sdks/ts-sdk/index.md)
-- [Python SDK](../sdks/python-sdk.md)
-- [Rust SDK](../sdks/rust-sdk.md)
+- [Python SDK](../sdks/python-sdk/index.md)
+- [Rust SDK](../sdks/rust-sdk/index.md)
 
 ---
 
@@ -369,6 +369,6 @@ There are two separate withdraw and deposit events instead of a single transfer 
 
 - [Aptos CLI](../tools/aptos-cli/use-cli/use-aptos-cli.md)
 - [TypeScript SDK](../sdks/ts-sdk/index.md)
-- [Python SDK](../sdks/python-sdk.md)
-- [Rust SDK](../sdks/rust-sdk.md)
+- [Python SDK](../sdks/python-sdk/index.md)
+- [Rust SDK](../sdks/rust-sdk/index.md)
 - [REST API specification](https://aptos.dev/nodes/aptos-api-spec#/)

--- a/apps/docusaurus/docs/tutorials/first-fungible-asset.md
+++ b/apps/docusaurus/docs/tutorials/first-fungible-asset.md
@@ -18,8 +18,8 @@ Make sure you have understood FA before moving on to the tutorial. If not, it is
 Install your preferred SDK from the below list:
 
 - [TypeScript SDK](../sdks/ts-sdk/index.md)
-- [Python SDK](../sdks/python-sdk.md)
-- [Rust SDK](../sdks/rust-sdk.md)
+- [Python SDK](../sdks/python-sdk/index.md)
+- [Rust SDK](../sdks/rust-sdk/index.md)
 
 ---
 
@@ -250,6 +250,6 @@ There are two separate withdraw and deposit events instead of a single transfer 
 - [Aptos CLI](../tools/aptos-cli/use-cli/use-aptos-cli.md)
 - [Fungible Asset](../standards/fungible-asset.md)
 - [TypeScript SDK](../sdks/ts-sdk/index.md)
-- [Python SDK](../sdks/python-sdk.md)
-- [Rust SDK](../sdks/rust-sdk.md)
+- [Python SDK](../sdks/python-sdk/index.md)
+- [Rust SDK](../sdks/rust-sdk/index.md)
 - [REST API specification](https://aptos.dev/nodes/aptos-api-spec#/)

--- a/apps/docusaurus/docs/tutorials/first-move-module.md
+++ b/apps/docusaurus/docs/tutorials/first-move-module.md
@@ -260,6 +260,6 @@ Other accounts can reuse the published module by calling the exact same function
 
 - [Account basics](../concepts/accounts.md)
 - [TypeScript SDK](../sdks/ts-sdk/index.md)
-- [Python SDK](../sdks/python-sdk.md)
-- [Rust SDK](../sdks/rust-sdk.md)
+- [Python SDK](../sdks/python-sdk/index.md)
+- [Rust SDK](../sdks/rust-sdk/index.md)
 - [REST API specification](https://aptos.dev/nodes/aptos-api-spec#/)

--- a/apps/docusaurus/docs/tutorials/first-multisig.md
+++ b/apps/docusaurus/docs/tutorials/first-multisig.md
@@ -17,9 +17,9 @@ Try out the above tutorials (which include dependency installations) before movi
 
 ## Step 1: Pick an SDK
 
-This tutorial, a community contribution, was created for the [Python SDK](../sdks/python-sdk.md).
+This tutorial, a community contribution, was created for the [Python SDK](../sdks/python-sdk/index.md).
 
-Other developers are invited to add support for the [TypeScript SDK](../sdks/ts-sdk/index.md), [Rust SDK](../sdks/rust-sdk.md), and [Unity SDK](../sdks/unity-sdk.md)!
+Other developers are invited to add support for the [TypeScript SDK](../sdks/ts-sdk/index.md), [Rust SDK](../sdks/rust-sdk/index.md), and [Unity SDK](../sdks/unity-sdk/index.md)!
 
 ## Step 2: Start the example
 

--- a/apps/docusaurus/docs/tutorials/first-transaction.md
+++ b/apps/docusaurus/docs/tutorials/first-transaction.md
@@ -15,8 +15,8 @@ This tutorial describes how to generate and submit transactions to the Aptos blo
 Install your preferred SDK from the below list:
 
 - [TypeScript SDK](../sdks/ts-sdk/index.md)
-- [Python SDK](../sdks/python-sdk.md)
-- [Rust SDK](../sdks/rust-sdk.md)
+- [Python SDK](../sdks/python-sdk/index.md)
+- [Rust SDK](../sdks/rust-sdk/index.md)
 
 ---
 
@@ -587,6 +587,6 @@ The transaction hash can be used to query the status of a transaction:
 
 - [Account basics](../concepts/accounts.md)
 - [TypeScript SDK](../sdks/ts-sdk/index.md)
-- [Python SDK](../sdks/python-sdk.md)
-- [Rust SDK](../sdks/rust-sdk.md)
+- [Python SDK](../sdks/python-sdk/index.md)
+- [Rust SDK](../sdks/rust-sdk/index.md)
 - [REST API specification](https://aptos.dev/nodes/aptos-api-spec#/)

--- a/apps/docusaurus/docs/tutorials/your-first-nft.md
+++ b/apps/docusaurus/docs/tutorials/your-first-nft.md
@@ -17,7 +17,7 @@ This tutorial describes how to create and transfer non-fungible assets on the Ap
 Install your preferred SDK from the below list:
 
 - [TypeScript SDK](../sdks/ts-sdk/index.md)
-- [Python SDK](../sdks/python-sdk.md)
+- [Python SDK](../sdks/python-sdk/index.md)
 
 ---
 
@@ -684,5 +684,5 @@ console.log(`Bob's digital assets balance: ${bobDigitalAssetsAfter.length}`);
 
 - [Account basics](../concepts/accounts.md)
 - [TypeScript SDK](../sdks/ts-sdk/index.md)
-- [Python SDK](../sdks/python-sdk.md)
+- [Python SDK](../sdks/python-sdk/index.md)
 - [REST API specification](https://aptos.dev/nodes/aptos-api-spec#/)

--- a/apps/docusaurus/src/components/sidebars.ts
+++ b/apps/docusaurus/src/components/sidebars.ts
@@ -379,9 +379,10 @@ const sidebars: SidebarsConfig = {
             "sdks/legacy-ts-sdk/sdk-tests",
           ],
         },
-        "sdks/python-sdk",
-        "sdks/rust-sdk",
-        "sdks/unity-sdk",
+        // Migrate these to proper folders when more info is there
+        "sdks/python-sdk/index",
+        "sdks/rust-sdk/index",
+        "sdks/unity-sdk/index",
       ],
     },
     {

--- a/apps/docusaurus/static/move-examples/large_packages/large_package_example/sources/five.move
+++ b/apps/docusaurus/static/move-examples/large_packages/large_package_example/sources/five.move
@@ -81,8 +81,8 @@
 ///
 /// Aptos currently provides three SDKs:
 /// 1. [Typescript](../sdks/ts-sdk/index.md)
-/// 2. [Python](../sdks/python-sdk.md)
-/// 3. [Rust](../sdks/rust-sdk.md)
+/// 2. [Python](../sdks/python-sdk/index.md)
+/// 3. [Rust](../sdks/rust-sdk/index.md)
 ///
 /// Almost all developers will benefit from exploring the CLI. [Using the CLI](../tools/aptos-cli-tool/use-aptos-cli.md) demonstrates how the CLI can be used to which includes creating accounts, transferring coins, and publishing modules.
 ///

--- a/apps/docusaurus/static/sdks/rust/README.md
+++ b/apps/docusaurus/static/sdks/rust/README.md
@@ -18,7 +18,7 @@ This SDK provides all the necessary components for building on top of the Aptos 
 
 ## Installing Rust SDK
 
-Please refer to [Rust SDK Doc](https://aptos.dev/sdks/rust-sdk/) for details on how to install the Rust SDK.
+Please refer to [Rust SDK Doc](https://aptos.dev/sdks/rust-sdk/index) for details on how to install the Rust SDK.
 
 ## License
 


### PR DESCRIPTION
### Description
This is reformatting the docs around Rust and Python SDKs to add pages on usage of each.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
