### PR TITLE
[docs] Add missing build step to "Your First NFT" documentation

### DIFF
--- a/apps/docusaurus/docs/tutorials/your-first-nft.md
+++ b/apps/docusaurus/docs/tutorials/your-first-nft.md
@@ -41,10 +41,11 @@ Navigate to the Typescript ESM examples directory:
 cd examples/typescript-esm
 ```
 
-Install the necessary dependencies:
+Install the necessary dependencies and build it:
 
 ```bash
 pnpm install
+pnpm build
 ```
 
 Run the Typescript [`simple_digital_asset`](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/examples/typescript-esm/simple_digital_asset.ts) example:


### PR DESCRIPTION
### Description

I noticed that in the "Your First NFT" documentation, under "Step 2: Run the example", there is only a mention of running pnpm install within the "example/typescript-esm" directory. However, the command to run the example, "pnpm run simple_digital_asset", executes "ts-node --esm dist/simple_digital_asset.js", which relies on the JavaScript files in the "dist" directory. This directory is only created after running "pnpm build", but the documentation does not specify the need to run "pnpm build" within the "example/typescript-esm" directory. The instructions only include a build step for the "aptos-ts-sdk".

I have added the missing build step to the documentation to ensure clarity and prevent potential confusion for users trying to run the example.

### Checklist

- Do all Lints pass?
  - [] Have you ran `pnpm spellcheck`?
  - [] Have you ran `pnpm fmt`?
  - [] Have you ran `pnpm lint`?
