### PR TITLE
[docs] Update deprecated API usage in "Your First NFT" chapter

### DIFF
--- a/apps/docusaurus/docs/tutorials/your-first-nft.md
+++ b/apps/docusaurus/docs/tutorials/your-first-nft.md
@@ -507,7 +507,7 @@ console.log(`Alice's collection: ${JSON.stringify(alicesCollection, null, 4)}`);
 To read an owned token's metadata:
 
 ```ts
-const alicesDigitalAsset = await aptos.getOwnedTokens({
+const alicesDigitalAsset = await aptos.getOwnedDigitalAssets({
   ownerAddress: alice.accountAddress,
   minimumLedgerVersion: BigInt(pendingTxn.version),
 });
@@ -545,7 +545,7 @@ Each object created from the `aptos_token.move` contract is a distinct asset. Th
   <TabItem value="typescript" label="Typescript">
 
 ```ts
-const alicesDigitalAsset = await aptos.getOwnedTokens({
+const alicesDigitalAsset = await aptos.getOwnedDigitalAssets({
   ownerAddress: alice.accountAddress,
   minimumLedgerVersion: BigInt(pendingTxn.version),
 });
@@ -556,7 +556,7 @@ console.log(
 ```
 
 ```ts title="Making the query to get the data"
-export async function getOwnedTokens(args: {
+export async function getOwnedDigitalAssets(args: {
   aptosConfig: AptosConfig;
   ownerAddress: AccountAddressInput;
   options?: PaginationArgs & OrderByArg<GetTokenActivityResponse[0]>;
@@ -581,7 +581,7 @@ export async function getOwnedTokens(args: {
   const data = await queryIndexer<GetCurrentTokenOwnershipQuery>({
     aptosConfig,
     query: graphqlQuery,
-    originMethod: "getOwnedTokens",
+    originMethod: "getOwnedDigitalAssets",
   });
 
   return data.current_token_ownerships_v2;
@@ -612,7 +612,7 @@ Each object created from the `aptos_token.move` contract is a distinct asset. Th
   <TabItem value="typescript" label="Typescript">
 
 ```ts
-const alicesDigitalAsset = await aptos.getOwnedTokens({
+const alicesDigitalAsset = await aptos.getOwnedDigitalAssets({
   ownerAddress: alice.accountAddress,
   minimumLedgerVersion: BigInt(pendingTxn.version),
 });
@@ -638,7 +638,7 @@ const pendingTxn = await aptos.waitForTransaction({
 ```
 
 ```ts title="Print each user's queried token amount"
-const alicesDigitalAssetsAfter = await aptos.getOwnedTokens({
+const alicesDigitalAssetsAfter = await aptos.getOwnedDigitalAssets({
   ownerAddress: alice.accountAddress,
   minimumLedgerVersion: BigInt(pendingTxn.version),
 });
@@ -646,7 +646,7 @@ console.log(
   `Alices's digital assets balance: ${alicesDigitalAssetsAfter.length}`,
 );
 
-const bobDigitalAssetsAfter = await aptos.getOwnedTokens({
+const bobDigitalAssetsAfter = await aptos.getOwnedDigitalAssets({
   ownerAddress: bob.accountAddress,
   minimumLedgerVersion: BigInt(pendingTxn.version),
 });


### PR DESCRIPTION
### Description

I have submitted a pull request addressing an issue in the "Your First NFT" chapter of the documentation. It was observed that the [Aptos Typescript SDK](https://github.com/aptos-labs/aptos-ts-sdk/blob/7d257b76730e54b524fc3bc3d163d6f6a55af7ed/src/api/digitalAsset.ts#L133) no longer includes the getOwnedTokens API. This API has been updated to getOwnedDigitalAssets.

The "Your First NFT" chapter was still using the outdated API, which could lead to confusion or errors for users following the guide. To rectify this, I have updated the documentation to use the new getOwnedDigitalAssets API, ensuring the documentation remains accurate and up-to-date with the current Aptos Typescript SDK.

Please review the changes and merge the pull request if everything is in order. This update will help maintain a smooth experience for developers engaging with Aptos NFTs.

### Checklist

- Do all Lints pass?
  - [] Have you ran `pnpm spellcheck`?
  - [] Have you ran `pnpm fmt`?
  - [] Have you ran `pnpm lint`?
