### PR TITLE
Fix: Correct step numbering in smart contract 'Add validations' section

### DIFF
--- a/apps/docusaurus/docs/tutorials/build-e2e-dapp/1-create-smart-contract.md
+++ b/apps/docusaurus/docs/tutorials/build-e2e-dapp/1-create-smart-contract.md
@@ -341,7 +341,7 @@ public entry fun create_task(account: &signer, content: String) acquires TodoLis
 }
 ```
 
-1. Add a check to the `complete_task` function to make sure the:
+2. Add a check to the `complete_task` function to make sure the:
    - signer has created a list.
    - task exists.
    - task is not completed.


### PR DESCRIPTION
## Overview

This pull request addresses a minor issue with the numbering of steps in the 'Add validations' section of the '1-create-smart-contract.md' tutorial.

## Changes

- The second step, which was incorrectly numbered as `1.`, has been corrected to `2.` to reflect the proper sequence.

## Impact

The change ensures that the tutorial's instructions are clear and logically ordered, which can prevent confusion for developers following the guide.

The corrected section now reads:

### Add validations

As this code now compiles, we want to have some validations and checks before creating a new task or updating the task as completed, so we can be sure our functions work as expected.

1. Add a check to the `create_task` function to make sure the signer account has a list:
   ...
2. Add a check to the `complete_task` function to make sure the:
   - signer has created a list.
   - task exists.
   - task is not completed.

Thank you for considering this fix, and I look forward to any feedback on this pull request.
