### PR TITLE
[nextra] Fix prettier linting - ignore .next

### DIFF
--- a/apps/nextra/.prettierignore
+++ b/apps/nextra/.prettierignore
@@ -1,0 +1,4 @@
+.next
+node_modules
+.turbo
+next-env.d.ts

--- a/apps/nextra/package.json
+++ b/apps/nextra/package.json
@@ -13,8 +13,8 @@
     "predev": "pnpm prebuild",
     "start": "next start -p 3030",
     "types:check": "tsc --noEmit",
-    "fmt": "prettier --write '**/*.(tsx|ts|jsx|js|json|md|html)'",
-    "lint": "prettier --check '**/*.(tsx|ts|jsx|js|json|md|html)'"
+    "fmt": "prettier --write '**/*.(tsx|ts|jsx|js|cjs|json|md|html)'",
+    "lint": "prettier --check '**/*.(tsx|ts|jsx|js|cjs|json|md|html)'"
   },
   "dependencies": {
     "@aptos-labs/aptos-nextra-config": "workspace:*",


### PR DESCRIPTION
### Description

Ignore `.next` folder (build folder)

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
