### PR TITLE
[nextra] Remove autocollapse

### DIFF
--- a/apps/nextra/theme.config.tsx
+++ b/apps/nextra/theme.config.tsx
@@ -241,7 +241,6 @@ const config: DocsThemeConfig = {
     },
   },
   sidebar: {
-    autoCollapse: true,
     defaultMenuCollapseLevel: 1,
     toggleButton: true,
   },


### PR DESCRIPTION
### Description
Was making it difficult to see content under certain directories. Kept [defaultCollapseLevel](https://nextra.site/docs/docs-theme/theme-configuration#menu-collapse-level) at 1 though.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
