### PR TITLE
[nextra] i18n - add middleware to handle unhandled languages

### DIFF
--- a/apps/nextra/middleware.ts
+++ b/apps/nextra/middleware.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import ISO6391 from "iso-639-1";
+
+const PUBLIC_FILE = /\.(.*)$/;
+
+const LOCALES = ["en"];
+
+export async function middleware(req: NextRequest) {
+  if (
+    req.nextUrl.pathname.startsWith("/_next") ||
+    req.nextUrl.pathname.includes("/api/") ||
+    PUBLIC_FILE.test(req.nextUrl.pathname)
+  ) {
+    console.log(`skip ${req.nextUrl}`);
+    return;
+  }
+  console.log(req.nextUrl);
+
+  // Determine language
+  let code = ISO6391.getAllCodes().find((locale) => {
+    if (req.nextUrl.pathname.startsWith(`/${locale}`)) {
+      return locale;
+    }
+
+    return undefined;
+  });
+
+  // If there is a language code, we determine if it's supported
+  if (code && LOCALES.some((locale) => locale === code)) {
+    // Supported locales should be passed normally
+    console.log(`Supported ${code}`);
+    return;
+  } else if (code) {
+    // If the language is unsupported
+    // Strip the unsupported language
+    req.nextUrl.pathname = req.nextUrl.pathname.substring(1 + code.length);
+
+    console.log(`Unsupported ${code}`);
+    return NextResponse.redirect(
+      new URL(`/en${req.nextUrl.pathname}`, req.url),
+    );
+  } else {
+    console.log(`Default to en`);
+    // Otherwise, redirect to en
+    // TODO: Currently there's some hydration issue which prevents using the
+    // '/' path instead of 'en'
+    return NextResponse.redirect(
+      new URL(`/en${req.nextUrl.pathname}`, req.url),
+    );
+  }
+}

--- a/apps/nextra/middleware.ts
+++ b/apps/nextra/middleware.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import ISO6391 from "iso-639-1";
+import { i18nConfig } from "@docs-config";
 
 const PUBLIC_FILE = /\.(.*)$/;
 
-const LOCALES = ["en"];
+const EN_LOCALE = i18nConfig.en.locale;
+const LOCALES = [EN_LOCALE];
 
 export async function middleware(req: NextRequest) {
   if (
@@ -11,10 +13,8 @@ export async function middleware(req: NextRequest) {
     req.nextUrl.pathname.includes("/api/") ||
     PUBLIC_FILE.test(req.nextUrl.pathname)
   ) {
-    console.log(`skip ${req.nextUrl}`);
     return;
   }
-  console.log(req.nextUrl);
 
   // Determine language
   let code = ISO6391.getAllCodes().find((locale) => {
@@ -26,26 +26,23 @@ export async function middleware(req: NextRequest) {
   });
 
   // If there is a language code, we determine if it's supported
-  if (code && LOCALES.some((locale) => locale === code)) {
+  if (code && LOCALES.includes(code)) {
     // Supported locales should be passed normally
-    console.log(`Supported ${code}`);
     return;
   } else if (code) {
     // If the language is unsupported
     // Strip the unsupported language
     req.nextUrl.pathname = req.nextUrl.pathname.substring(1 + code.length);
 
-    console.log(`Unsupported ${code}`);
     return NextResponse.redirect(
-      new URL(`/en${req.nextUrl.pathname}`, req.url),
+      new URL(`/${EN_LOCALE}${req.nextUrl.pathname}`, req.url),
     );
   } else {
-    console.log(`Default to en`);
-    // Otherwise, redirect to en
+    // Otherwise, redirect to default locale
     // TODO: Currently there's some hydration issue which prevents using the
     // '/' path instead of 'en'
     return NextResponse.redirect(
-      new URL(`/en${req.nextUrl.pathname}`, req.url),
+      new URL(`/${EN_LOCALE}${req.nextUrl.pathname}`, req.url),
     );
   }
 }

--- a/apps/nextra/package.json
+++ b/apps/nextra/package.json
@@ -31,6 +31,7 @@
     "graphql": "^16.8.1",
     "graphql-ws": "^5.16.0",
     "intersection-observer": "^0.10.0",
+    "iso-639-1": "^3.1.2",
     "markdown-to-jsx": "^6.11.4",
     "next": "^13.5.6",
     "nextra": "3.0.0-alpha.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,9 @@ importers:
       intersection-observer:
         specifier: ^0.10.0
         version: 0.10.0
+      iso-639-1:
+        specifier: ^3.1.2
+        version: 3.1.2
       markdown-to-jsx:
         specifier: ^6.11.4
         version: 6.11.4(react@18.2.0)
@@ -14117,6 +14120,11 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  /iso-639-1@3.1.2:
+    resolution: {integrity: sha512-Le7BRl3Jt9URvaiEHJCDEdvPZCfhiQoXnFgLAWNRhzFMwRFdWO7/5tLRQbiPzE394I9xd7KdRCM7S6qdOhwG5A==}
+    engines: {node: '>=6.0'}
+    dev: false
 
   /isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}


### PR DESCRIPTION

### Description
This adds '/' -> '/en' and '/fr' etc. -> '/en' for now.

I wanted to change all of '/en' to just '/', but there's some hydration issue when using a rewrite.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
