### PR TITLE
Move docs help into additional resources, and remove token hub

### DIFF
--- a/apps/nextra/pages/en/_meta.ts
+++ b/apps/nextra/pages/en/_meta.ts
@@ -83,16 +83,10 @@ export default {
         newWindow: true,
         type: "page",
       },
-      token_hub: {
-        title: "Token Hub ↗",
-        href: "",
-        newWindow: true,
+      docs: {
+        title: "How to modify the docs ↗",
         type: "page",
       },
     },
-  },
-  docs: {
-    type: "page",
-    title: "Docs Help",
   },
 };

--- a/apps/nextra/pages/en/_meta.ts
+++ b/apps/nextra/pages/en/_meta.ts
@@ -84,7 +84,8 @@ export default {
         type: "page",
       },
       docs: {
-        title: "How to modify the docs ↗",
+        title: "Contribute",
+        href: "/docs",
         type: "page",
       },
     },


### PR DESCRIPTION
### Description
Token hub doesn't have a URI, and want to hide the docs help with a more sensible name

### Checklist

- Do all Lints pass?
  - [] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
