### PR TITLE
[nextra] Add API explorer links

### DIFF
--- a/apps/nextra/pages/en/build/apis/_meta.tsx
+++ b/apps/nextra/pages/en/build/apis/_meta.tsx
@@ -1,0 +1,5 @@
+export default {
+  "fullnode-rest-api": "Fullnode REST API",
+  "aptos-labs-developer-portal": "Developer Portal",
+  "error-codes": "Error Codes",
+};

--- a/apps/nextra/pages/en/build/apis/fullnode-rest-api.mdx
+++ b/apps/nextra/pages/en/build/apis/fullnode-rest-api.mdx
@@ -3,15 +3,33 @@ title: "Fullnode Rest API"
 ---
 
 import { Callout } from 'nextra/components'
+import { Card, Cards } from '@components/index'
 
-# Use the Aptos Fullnode REST API
+# Aptos Fullnode REST API
 
-If you wish to employ the [Aptos API](https://aptos.dev/nodes/aptos-api-spec/#/), then this guide is for you. This guide
-will walk you through all you need to integrate the Aptos blockchain into your platform with the Aptos API.
+This API - embedded into Fullnodes - provides a simple, low latency, yet low-level way of reading state and submitting transactions to the Aptos Blockchain. It also supports transaction simulation.
+For more advanced queries, we recommend using the [Indexer GraphQL API](../indexer.mdx).
 
 <Callout type="info">
 Also see the [System Integrators Guide](../guides/system-integrators-guide.md) {/* TODO fix link */} for a thorough walkthrough of Aptos integration.
 </Callout>
+
+## Fullnode REST API Explorer
+
+<Cards>
+  <Card href="https://fullnode.mainnet.aptoslabs.com/v1/spec#/">
+    <Card.Title>Mainnet Fullnode REST API</Card.Title>
+    <Card.Description>REST API Explorer for Mainnet</Card.Description>
+  </Card>
+  <Card href="https://fullnode.testnet.aptoslabs.com/v1/spec#/">
+    <Card.Title>Testnet Fullnode REST API</Card.Title>
+    <Card.Description>REST API Explorer for Testnet</Card.Description>
+  </Card>
+  <Card href="https://fullnode.devnet.aptoslabs.com/v1/spec#/">
+    <Card.Title>Devnet Fullnode REST API</Card.Title>
+    <Card.Description>REST API Explorer for Devnet</Card.Description>
+  </Card>
+</Cards>
 
 ## Understanding rate limits
 
@@ -92,17 +110,17 @@ aptos move view --function-id devnet::message::get_message --profile devnet --ar
 
 In the TypeScript SDK, a view function request would look like this:
 
-```typescript
-    import { Aptos } from "@aptos-labs/ts-sdk";
+```ts filename="index.ts"
+import { Aptos } from "@aptos-labs/ts-sdk";
 
-    const aptos = new Aptos();
-    const [balance] = aptos.view<[string]>({
-      function: "0x1::coin::balance",
-      typeArguments: ["0x1::aptos_coin::AptosCoin"],
-      functionArguments: [alice.accountAddress]
-    });
+const aptos = new Aptos();
+const [balance] = aptos.view<[string]>({
+  function: "0x1::coin::balance",
+  typeArguments: ["0x1::aptos_coin::AptosCoin"],
+  functionArguments: [alice.accountAddress]
+});
 
-    expect(balance).toBe("100000000");
+expect(balance).toBe("100000000");
 ```
 
 The view function returns a list of values as a vector. By default, the results are returned in JSON format; however,

--- a/apps/nextra/pages/en/build/indexer.mdx
+++ b/apps/nextra/pages/en/build/indexer.mdx
@@ -1,12 +1,18 @@
 ---
-title: "Learn about Indexing"
+title: "Indexer"
 ---
 
 import { IndexerBetaNotice, ThemedImage } from '@components/index';
 
-# Learn About Indexing
+# Indexer
 
 <IndexerBetaNotice />
+
+## Purpose
+
+Typical applications built on the Aptos blockchain, on any blockchain for that matter, require the raw blockchain data to be shaped and stored in an application-specific manner. This is essential to supporting low-latency and rich experiences when consuming blockchain data in end-user apps from millions of users. The [Aptos Node API](../network/nodes/aptos-api-spec.mdx) provides a lower level, stable and generic API and is not designed to support data shaping and therefore cannot support rich end-user experiences directly.
+
+The Aptos Indexer is the answer to this need, allowing the data shaping critical to real-time app use. See this high-level diagram for how Aptos indexing works:
 
 ## Quick Start
 
@@ -22,11 +28,7 @@ Refer to this role-oriented guide to help you quickly find the relevant docs:
   - See docs for the [Labs-Hosted Indexer API](./indexer/api/labs-hosted.mdx).
   - See the [Indexer Example Queries](./indexer/api/example-queries.mdx).
 
-# Architecture Overview
-
-Typical applications built on the Aptos blockchain, on any blockchain for that matter, require the raw blockchain data to be shaped and stored in an application-specific manner. This is essential to supporting low-latency and rich experiences when consuming blockchain data in end-user apps from millions of users. The [Aptos Node API](../network/nodes/aptos-api-spec.mdx) provides a lower level, stable and generic API and is not designed to support data shaping and therefore cannot support rich end-user experiences directly.
-
-The Aptos Indexer is the answer to this need, allowing the data shaping critical to real-time app use. See this high-level diagram for how Aptos indexing works:
+## Architecture Overview
 
 <center>
 <ThemedImage


### PR DESCRIPTION
### Description

Add links to fullnode spec for API page for `mainnet`, `testnet`, `devnet`. Also fix some small things in indexer.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
