### PR TITLE
[docusaurus] Put a tip pointing users to Aptos learn on the move page

### DIFF
--- a/apps/docusaurus/docs/move/move-on-aptos.md
+++ b/apps/docusaurus/docs/move/move-on-aptos.md
@@ -6,6 +6,10 @@ title: "Move on Aptos"
 
 To begin your journey in developing Move, we provide the following resources:
 
+:::tip
+All the tutorials have been moved to [Aptos Learn](https://learn.aptoslabs.com/tutorials) for a prettier experience.
+:::
+
 - [Your first move module](../tutorials/first-move-module.md) to walks you through compiling, deploying, and interacting with Move.
 - [Aptos Move Book](./book/SUMMARY.md) to teach you many of the general Move concepts.
 - [The Move tutorial](https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/move-examples/move-tutorial) to cover the basics of programming with Move.


### PR DESCRIPTION
### Description
Link to Aptos Learn as a more ideal tutorial location

### Checklist

- Do all Lints pass?
  - [] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
