### PR TITLE
Remove unnecessary External Link Icon & Copy Edit for Blockchain Features heading

### DIFF
--- a/apps/nextra/components/landing/sections/TitleSection.tsx
+++ b/apps/nextra/components/landing/sections/TitleSection.tsx
@@ -13,7 +13,7 @@ export function TitleSection() {
     asChild: true,
     children: (
       <Link href={`${locale}/build/quick-start`}>
-        Quick Start <IconArrowTopRight />
+        Quick Start
       </Link>
     ),
   };

--- a/apps/nextra/docs.config.js
+++ b/apps/nextra/docs.config.js
@@ -81,7 +81,7 @@ export const i18nConfig = Object.freeze({
 
     // Blockchain Section
     blockchainSectionHeadline:
-      "Discover blockchain features only possible on Aptos",
+      "Discover blockchain features on Aptos",
     performanceLabel: "Performance",
     performanceDescription:
       "Redefine blockchain performance with high TPS and low latency",


### PR DESCRIPTION
### Description


- Remove "only possible on Aptos" from Blockchain Features section as requested from Marketing. 
- Remove unnecessary External Link Icon from "Quick Start" CTA button. The purpose is to indicate that clicking the link will take the user to an external website, however this is an internal link.

<img width="950" alt="image" src="https://github.com/aptos-labs/developer-docs/assets/98909677/f39c8800-542a-4d46-a9fb-c4ef81e0b4a2">

<img width="1319" alt="image" src="https://github.com/aptos-labs/developer-docs/assets/98909677/2974c831-bf00-45a8-a8b9-dab0d146b378">



### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
