### PR TITLE
Fixes to inline function docs in Aptos Move book

### DIFF
--- a/apps/docusaurus/docs/move/book/functions.md
+++ b/apps/docusaurus/docs/move/book/functions.md
@@ -581,8 +581,9 @@ There are plans to loosen some of these restrictions in the future, but for now,
 
 - Only inline functions can have function parameters.
 - Only explicit lambda expressions can be passed as an argument to an inline function's function parameters.
-- cannot have `return` expressions; or free `break` or `continue` expressions (occurring outside of a loop)
-- Inline functions or lambda expressions cannot return lambda expressions.
+- Inline functions and lambda expressions:
+  - cannot have `return` expressions; or free `break` or `continue` expressions (occurring outside of a loop).
+  - cannot return lambda expressions.
 - Cyclic recursion involving only inline functions is not allowed.
 - Parameters in lambda expressions must not be type annotated (e.g., `|x: u64| x + 1` is not allowed): their types are inferred.
 

--- a/apps/docusaurus/docs/move/book/functions.md
+++ b/apps/docusaurus/docs/move/book/functions.md
@@ -581,7 +581,7 @@ There are plans to loosen some of these restrictions in the future, but for now,
 
 - Only inline functions can have function parameters.
 - Only explicit lambda expressions can be passed as an argument to an inline function's function parameters.
-- Inline functions and lambda expressions cannot have `return`, `break`, or `continue` expressions.
+- cannot have `return` expressions; or free `break` or `continue` expressions (occurring outside of a loop)
 - Inline functions or lambda expressions cannot return lambda expressions.
 - Cyclic recursion involving only inline functions is not allowed.
 - Parameters in lambda expressions must not be type annotated (e.g., `|x: u64| x + 1` is not allowed): their types are inferred.
@@ -593,6 +593,39 @@ There are plans to loosen some of these restrictions in the future, but for now,
 - Avoid marking large functions that are called at different locations as inline. Also avoid inline functions calling lots of other inline functions transitively.
   These may lead to excessive inlining and increase the bytecode size.
 - Inline functions can be useful for returning references to global storage, which non-inline functions cannot do.
+
+### Inline functions and references
+
+As mentioned briefly [in a "tip" above](#return-type) `inline` functions can use references more freely than normal functions.
+
+For example, actual arguments to a call to a non-`inline` function may not be aliased unsafely
+(multiple `&` parameters referring to the same object, with at least one of them `&mut`),
+but calls to `inline` functions do not necessarily have that restriction, as long as no reference
+usage conflicts remain after the function is inlined.
+
+```move
+inline fun add(dest: &mut u64, a: &u64, b: &u64) {
+    *dest = *a + *b;
+}
+
+fun user(...) {
+    ...
+    x = 3;
+    add(&mut x, &x, &x);  // legal only because of inlining
+    ...
+}
+```
+
+A reference-typed value returned from a non-inline function must be derived from a reference parameter
+passed to the function, but this need not be the case for an inline function, as long as the referred
+value is in the function scope after inlining.
+
+The exact details of reference safety and "borrow checking" are complex and documented elsewhere.
+Advanced Move users find new expressiveness by understanding that 
+"borrow checking" happens only after all `inline` function calls are expanded.
+
+However, with this power comes new responsibility: documentation of a nontrivial `inline` function should
+probably explain any underlying restrictions on reference parameters and results at a call site.
 
 ## Dot (receiver) function call style
 
@@ -620,3 +653,4 @@ The call `s.foo(1)` is syntactic sugar for `foo(&s, 1)`. Notice that the compile
 The type of the `self` argument can be a struct or an immutable or mutable reference to a struct. The struct must be declared in the same module as the function.
 
 Notice that you do not need to `use` the modules which introduce receiver functions. The compiler will find those functions automatically based on the argument type of `s` in a call like `s.foo(1)`. This, in combination with the automatic insertion of reference operators, can make code using this syntax significantly more concise.
+

--- a/apps/nextra/pages/en/build/move/book/functions.mdx
+++ b/apps/nextra/pages/en/build/move/book/functions.mdx
@@ -616,8 +616,9 @@ There are plans to loosen some of these restrictions in the future, but for now,
 
 - Only inline functions can have function parameters.
 - Only explicit lambda expressions can be passed as an argument to an inline function's function parameters.
-- Inline functions and lambda expressions cannot have `return`, `break`, or `continue` expressions.
-- Inline functions or lambda expressions cannot return lambda expressions.
+- Inline functions and lambda expressions
+  - cannot have `return` expressions; or free `break` or `continue` expressions (occurring outside of a loop)
+  - cannot return lambda expressions.
 - Cyclic recursion involving only inline functions is not allowed.
 - Parameters in lambda expressions must not be type annotated (e.g., `|x: u64| x + 1` is not allowed): their types are inferred.
 
@@ -628,6 +629,39 @@ There are plans to loosen some of these restrictions in the future, but for now,
 - Avoid marking large functions that are called at different locations as inline. Also avoid inline functions calling lots of other inline functions transitively.
   These may lead to excessive inlining and increase the bytecode size.
 - Inline functions can be useful for returning references to global storage, which non-inline functions cannot do.
+
+### Inline functions and references
+
+As mentioned briefly [in a "tip" above](#return-type) `inline` functions can use references more freely than normal functions.
+
+For example, actual arguments to a call to a non-`inline` function may not be aliased unsafely
+(multiple `&` parameters referring to the same object, with at least one of them `&mut`),
+but calls to `inline` functions do not necessarily have that restriction, as long as no reference
+usage conflicts remain after the function is inlined.
+
+```move
+inline fun add(dest: &mut u64, a: &u64, b: &u64) {
+    *dest = *a + *b;
+}
+
+fun user(...) {
+    ...
+    x = 3;
+    add(&mut x, &x, &x);  // legal only because of inlining
+    ...
+}
+```
+
+A reference-typed value returned from a non-inline function must be derived from a reference parameter
+passed to the function, but this need not be the case for an inline function, as long as the referred
+value is in the function scope after inlining.
+
+The exact details of reference safety and "borrow checking" are complex and documented elsewhere.
+Advanced Move users find new expressiveness by understanding that 
+"borrow checking" happens only after all `inline` function calls are expanded.
+
+However, with this power comes new responsibility: documentation of a nontrivial `inline` function should
+probably explain any underlying restrictions on reference parameters and results at a call site.
 
 ## Dot (receiver) function call style
 


### PR DESCRIPTION
Fixes https://github.com/aptos-labs/aptos-core/issues/12043.
- refine statement about `break` and `continue` in lambda.
- add some discussion of `inline` and reference parameters/ results.

### Description

### Checklist

- Do all Lints pass?
  - [] Have you ran `pnpm spellcheck`?
  - [] Have you ran `pnpm fmt`?
  - [] Have you ran `pnpm lint`?
