### PR TITLE
Remove double borders from landing page

### DIFF
--- a/apps/nextra/components/landing/components/Accordion.tsx
+++ b/apps/nextra/components/landing/components/Accordion.tsx
@@ -37,7 +37,7 @@ export function Accordion({
         <AccordionPrimitive.Item
           key={item.id}
           value={item.id}
-          className="flex flex-col overflow-hidden data-[state=open]:bg-background-elevated [&:not(:first-child)]:border-t-2 border-border-divider transition-colors"
+          className="flex flex-col overflow-hidden data-[state=open]:bg-background-elevated [&:not(:first-child)]:border-t border-border-divider transition-colors"
         >
           <AccordionPrimitive.Header asChild>
             <HeadingLevel

--- a/apps/nextra/components/landing/sections/BlockchainSection.tsx
+++ b/apps/nextra/components/landing/sections/BlockchainSection.tsx
@@ -17,7 +17,12 @@ export function BlockchainSection() {
   return (
     <Section>
       <SectionHeader>{t.blockchainSectionHeadline}</SectionHeader>
-      <div className="grid w-full sm:max-w-[591px] lg:max-w-[1176px] lg:grid-cols-[repeat(auto-fit,minmax(341px,1fr))]">
+      <div
+        className="
+          grid w-full sm:max-w-[591px] lg:max-w-[1176px] lg:grid-cols-[repeat(auto-fit,minmax(341px,1fr))]
+          sm:border-t sm:border-l border-border-divider sm:-mb-px
+        "
+      >
         <FeatureCard
           illustration={
             <PerformanceIllustration className={illustrationStyles} />
@@ -114,8 +119,8 @@ function FeatureCard(props: FeatureCardProps) {
     <Link
       href={props.href}
       className="
-        no-underline flex flex-col p-8 gap-8 border-t border-b sm:border border-border-divider rounded-0
-        text-text-primary hover:bg-background-elevated transition-colors
+        no-underline flex flex-col p-8 gap-8 text-text-primary hover:bg-background-elevated transition-colors
+        rounded-0 max-sm:border-t sm:border-b sm:border-r border-border-divider
       "
     >
       {props.illustration}

--- a/apps/nextra/components/landing/sections/DevelopersSection.tsx
+++ b/apps/nextra/components/landing/sections/DevelopersSection.tsx
@@ -56,7 +56,7 @@ function DevelopersCard(props: DevelopersCard) {
     <div
       className="
         flex flex-col flex-1 p-8 w-full sm:max-w-[591px] lg:max-w-[393px] gap-8
-        border-t border-b sm:border border-border-divider rounded-0
+        border-t sm:border-l sm:border-r lg:border-r-0 lg:last:border-r border-border-divider rounded-0
         text-text-primary hover:bg-background-elevated transition-colors
       "
     >

--- a/apps/nextra/components/landing/sections/MoveSection.tsx
+++ b/apps/nextra/components/landing/sections/MoveSection.tsx
@@ -92,14 +92,11 @@ export function MoveSection() {
             className="md:w-[666px] xl:w-[780px] max-md:h-[415px] lg:h-[635px] xl:h-[735px]"
           />
         </div>
-        <Carousel
-          onChange={setActiveExample}
-          className="md:hidden border-b-border-divider border-b-100"
-        >
+        <Carousel onChange={setActiveExample} className="md:hidden">
           {exampleItems.map((item) => (
             <div
               key={item.id}
-              className="flex flex-col gap-4 p-8 w-full border-b-border-divider border-b-100"
+              className="flex flex-col gap-4 p-8 w-full border-b-border-divider border-b"
             >
               <div className="flex items-center justify-between gap-4">
                 <h3 className="label-300 text-text-primary">{item.label}</h3>

--- a/apps/nextra/components/landing/sections/TestimonialsSection.tsx
+++ b/apps/nextra/components/landing/sections/TestimonialsSection.tsx
@@ -54,7 +54,7 @@ export function TestimonialsSection() {
     <div
       key={i}
       className="
-        flex flex-col px-8 py-10 gap-8 border-x border-t border-border-divider h-full
+        flex flex-col px-8 py-10 gap-8 border-t border-l border-border-divider h-full
         max-md:bg-background-elevated md:[[data-active=true]>&]:bg-background-elevated
         transition-colors duration-300
       "

--- a/apps/nextra/components/landing/sections/ToolingSection.tsx
+++ b/apps/nextra/components/landing/sections/ToolingSection.tsx
@@ -91,8 +91,8 @@ function ToolingCard(props: ToolingCardProps) {
       href={props.href}
       className="
         no-underline flex flex-col flex-1 p-8 w-full sm:max-w-[591px] gap-8
-        border-t border-b sm:border border-border-divider rounded-0
-        text-text-primary hover:bg-background-elevated transition-colors
+        border-t sm:border-l sm:border-r lg:border-r-0 lg:last:border-r rounded-0
+        border-border-divider text-text-primary hover:bg-background-elevated transition-colors
       "
     >
       <div className="relative w-full aspect-[525/294]">


### PR DESCRIPTION
### Description

This PR removes all the double borders from the landing page.

### Checklist

- Do all Lints pass?
  - [] Have you ran `pnpm spellcheck`?
  - [] Have you ran `pnpm fmt`?
  - [] Have you ran `pnpm lint`?
