### PR TITLE
[aptos-object] Fix syntax errors in Object examples

### DIFF
--- a/apps/docusaurus/docs/standards/aptos-object.md
+++ b/apps/docusaurus/docs/standards/aptos-object.md
@@ -159,8 +159,8 @@ struct DeleteRefStore has key {
     delete_ref: DeleteRef,
 }
 
-public fun delete_liquidity_pool(liquidity_pool: Object<LiquidityPool>) {
-    let liquidity_pool_address = object::object_address(liquidity_pool);
+public fun delete_liquidity_pool(liquidity_pool: Object<LiquidityPool>) acquires LiquidityPool, DeleteRefStore {
+    let liquidity_pool_address = object::object_address(&liquidity_pool);
     // Remove all resources added to the liquidity pool object.
     let LiquidityPool {
         token_a: _,
@@ -170,7 +170,7 @@ public fun delete_liquidity_pool(liquidity_pool: Object<LiquidityPool>) {
     } = move_from<LiquidityPool>(liquidity_pool_address);
     let DeleteRefStore { delete_ref } = move_from<DeleteRefStore>(liquidity_pool_address);
     // Delete the object itself.
-    object::delete_object(delete_ref);
+    object::delete(delete_ref);
 }
 ```
 
@@ -184,15 +184,15 @@ struct TransferRefStore has key {
     transfer_ref: TransferRef,
 }
 
-public fun disable_owner_transfer(liquidity_pool: Object<LiquidityPool>) {
-    let liquidity_pool_address = object::object_address(liquidity_pool);
-    let transfer_ref = &borrow_global_mut<TransferRefStore>(liquidity_pool_address).transfer_ref;
+public fun disable_owner_transfer(liquidity_pool: Object<LiquidityPool>) acquires TransferRefStore {
+    let liquidity_pool_address = object::object_address(&liquidity_pool);
+    let transfer_ref = &borrow_global<TransferRefStore>(liquidity_pool_address).transfer_ref;
     object::disable_ungated_transfer(transfer_ref);
 }
 
-public fun creator_transfer(liquidity_pool: Object<LiquidityPool>, new_owner: address) {
-    let liquidity_pool_address = object::object_address(liquidity_pool);
-    let transfer_ref = &borrow_global_mut<TransferRefStore>(liquidity_pool_address).transfer_ref;
+public fun creator_transfer(liquidity_pool: Object<LiquidityPool>, new_owner: address) acquires TransferRefStore {
+    let liquidity_pool_address = object::object_address(&liquidity_pool);
+    let transfer_ref = &borrow_global<TransferRefStore>(liquidity_pool_address).transfer_ref;
     object::transfer_with_ref(object::generate_linear_transfer_ref(transfer_ref), new_owner);
 }
 ```
@@ -200,8 +200,8 @@ public fun creator_transfer(liquidity_pool: Object<LiquidityPool>, new_owner: ad
 Once the resources have been created on an object, they can be modified by the creator modules without the refs/ Example:
 
 ```rust
-public entry fun modify_reserves(liquidity_pool: Object<LiquidityPool>) {
-    let liquidity_pool = &mut borrow_global_mut<LiquidityPool>(liquidity_pool);
+public entry fun modify_reserves(liquidity_pool: Object<LiquidityPool>) acquires LiquidityPool {
+    let liquidity_pool = borrow_global_mut<LiquidityPool>(object::object_address(&liquidity_pool));
     liquidity_pool.reserves_a = liquidity_pool.reserves_a + 1000;
 }
 ```
@@ -247,23 +247,30 @@ struct CreateLiquidtyPoolEvent {
     reserves_b: u128,
 }
 
-public entry fun create_liquidity_pool_with_events() {
+public entry fun create_liquidity_pool_with_events(
+        token_a: Object<FungibleAsset>,
+        token_b: Object<FungibleAsset>,
+        reserves_a: u128,
+        reserves_b: u128
+) {
     let exchange_signer = &get_exchange_signer();
     let liquidity_pool_constructor_ref = &object::create_object_from_account(exchange_signer);
     let liquidity_pool_signer = &object::generate_signer(liquidity_pool_constructor_ref);
     let event_handle = object::new_event_handle<CreateLiquidtyPoolEvent>(liquidity_pool_signer);
-    event::emit<CreateLiquidtyPoolEvent>(event_handle, CreateLiquidtyPoolEvent {
-        token_a: token_a,
-        token_b: token_b,
-        reserves_a: reserves_a,
-        reserves_b: reserves_b,
+    event::emit_event<CreateLiquidtyPoolEvent>(&mut event_handle, CreateLiquidtyPoolEvent {
+        token_a: object::object_address(&token_a),
+        token_b: object::object_address(&token_b),
+        reserves_a,
+        reserves_b,
     });
-    let liquidity_pool = move_to(liquidity_pool_signer, LiquidityPool {
-        token_a: token_a,
-        token_b: token_b,
-        reserves_a: reserves_a,
-        reserves_b: reserves_b,
-        create_events: event_handle,
+    move_to(liquidity_pool_signer, LiquidityPool {
+        token_a,
+        token_b,
+        reserves_a,
+        reserves_b
+    });
+    move_to(liquidity_pool_signer, LiquidityPoolEventStore {
+        create_events: event_handle
     });
 }
 ```

--- a/apps/nextra/pages/en/build/standards/aptos-object.mdx
+++ b/apps/nextra/pages/en/build/standards/aptos-object.mdx
@@ -237,8 +237,8 @@ module 0x42::example {
     delete_ref: DeleteRef,
   }
 
-  public fun delete_liquidity_pool(liquidity_pool: Object<LiquidityPool>) {
-    let liquidity_pool_address = object::object_address(liquidity_pool);
+  public fun delete_liquidity_pool(liquidity_pool: Object<LiquidityPool>) acquires LiquidityPool, DeleteRefStore {
+    let liquidity_pool_address = object::object_address(&liquidity_pool);
     // Remove all resources added to the liquidity pool object.
     let LiquidityPool {
       token_a: _,
@@ -248,7 +248,7 @@ module 0x42::example {
     } = move_from<LiquidityPool>(liquidity_pool_address);
     let DeleteRefStore { delete_ref } = move_from<DeleteRefStore>(liquidity_pool_address);
     // Delete the object itself.
-    object::delete_object(delete_ref);
+    object::delete(delete_ref);
   }
 }
 ```
@@ -267,17 +267,17 @@ module 0x42::example {
     transfer_ref: TransferRef,
   }
 
-  public fun disable_owner_transfer(liquidity_pool: Object<LiquidityPool>) {
-    let liquidity_pool_address = object::object_address(liquidity_pool);
+  public fun disable_owner_transfer(liquidity_pool: Object<LiquidityPool>) acquires TransferRefStore {
+    let liquidity_pool_address = object::object_address(&liquidity_pool);
     let transfer_ref = &borrow_global_mut<TransferRefStore>(
       liquidity_pool_address
     ).transfer_ref;
     object::disable_ungated_transfer(transfer_ref);
   }
 
-  public fun creator_transfer(liquidity_pool: Object<LiquidityPool>, new_owner: address) {
-    let liquidity_pool_address = object::object_address(liquidity_pool);
-    let transfer_ref = &borrow_global_mut<TransferRefStore>(
+  public fun creator_transfer(liquidity_pool: Object<LiquidityPool>, new_owner: address) acquires TransferRefStore {
+    let liquidity_pool_address = object::object_address(&liquidity_pool);
+    let transfer_ref = &borrow_global<TransferRefStore>(
       liquidity_pool_address
     ).transfer_ref;
     object::transfer_with_ref(object::generate_linear_transfer_ref(transfer_ref), new_owner);
@@ -290,8 +290,8 @@ creator modules without the refs/ Example:
 
 ```move
 module 0x42::example {
-  public entry fun modify_reserves(liquidity_pool: Object<LiquidityPool>) {
-    let liquidity_pool = &mut borrow_global_mut<LiquidityPool>(liquidity_pool);
+  public entry fun modify_reserves(liquidity_pool: Object<LiquidityPool>) acquires LiquidityPool {
+    let liquidity_pool = borrow_global_mut<LiquidityPool>((object::object_address(&liquidity_pool)));
     liquidity_pool.reserves_a = liquidity_pool.reserves_a + 1000;
   }
 }
@@ -339,6 +339,10 @@ These event handles can be stored in the custom resources added to the object. E
 
 ```move
 module 0x42::example {
+  use aptos_framework::event;
+  use aptos_framework::fungible_asset::FungibleAsset;
+  use aptos_framework::object::{Self, Object};
+
   struct LiquidityPoolEventStore has key {
     create_events: event::EventHandle<CreateLiquidtyPoolEvent>,
   }
@@ -350,7 +354,12 @@ module 0x42::example {
     reserves_b: u128,
   }
 
-  public entry fun create_liquidity_pool_with_events() {
+  public entry fun create_liquidity_pool_with_events(
+        token_a: Object<FungibleAsset>,
+        token_b: Object<FungibleAsset>,
+        reserves_a: u128,
+        reserves_b: u128
+  ) {
     let exchange_signer = &get_exchange_signer();
     let liquidity_pool_constructor_ref = &object::create_object_from_account(
       exchange_signer
@@ -361,18 +370,20 @@ module 0x42::example {
     let event_handle = object::new_event_handle<CreateLiquidtyPoolEvent>(
       liquidity_pool_signer
     );
-    event::emit<CreateLiquidtyPoolEvent>(event_handle, CreateLiquidtyPoolEvent {
-      token_a,
-      token_b,
+    event::emit_event<CreateLiquidtyPoolEvent>(&mut event_handle, CreateLiquidtyPoolEvent {
+      token_a: object::object_address(&token_a),
+      token_b: object::object_address(&token_b),
       reserves_a,
       reserves_b,
     });
-    let liquidity_pool = move_to(liquidity_pool_signer, LiquidityPool {
+    move_to(liquidity_pool_signer, LiquidityPool {
       token_a,
       token_b,
       reserves_a,
-      reserves_b,
-      create_events: event_handle,
+      reserves_b
+    });
+    move_to(liquidity_pool_signer, LiquidityPoolEventStore {
+      create_events: event_handle
     });
   }
 }


### PR DESCRIPTION
### Description

This PR addresses syntax errors in the examples provided in the Object documentation, enhancing clarity and understanding. 

Users can more easily comprehend the code logic, thereby improving the readability and usability of the documentation.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
