### PR TITLE
Fill in more landing page hrefs

### DIFF
--- a/apps/nextra/components/landing/sections/BlockchainSection.tsx
+++ b/apps/nextra/components/landing/sections/BlockchainSection.tsx
@@ -29,7 +29,7 @@ export function BlockchainSection() {
           }
           label={t.performanceLabel}
           description={t.performanceDescription}
-          href="" // TODO: Add link to relevant docs page
+          href="https://aptosfoundation.org/#network-numbers"
         />
         <FeatureCard
           illustration={
@@ -37,7 +37,7 @@ export function BlockchainSection() {
           }
           label={t.parallelExecutionLabel}
           description={t.parallelExecutionDescription}
-          href="" // TODO: Add link to relevant docs page
+          href="https://medium.com/aptoslabs/block-stm-how-we-execute-over-160k-transactions-per-second-on-the-aptos-blockchain-3b003657e4ba"
         />
         <FeatureCard
           illustration={
@@ -45,12 +45,12 @@ export function BlockchainSection() {
           }
           label={t.validatorsLabel}
           description={t.validatorsDescription}
-          href="" // TODO: Add link to relevant docs page
+          href={`/${locale}/network/blockchain/learn-about-aptos/validator-nodes`}
         />
         <FeatureCard
           label={t.keylessLabel}
           description={t.keylessDescription}
-          href="" // TODO: Add link to relevant docs page
+          href={`/${locale}/build/advanced-guides/keyless-accounts`}
         />
         <FeatureCard
           label={t.passkeysLabel}
@@ -60,47 +60,47 @@ export function BlockchainSection() {
         <FeatureCard
           label={t.randomnessLabel}
           description={t.randomnessDescription}
-          href="" // TODO: Add link to relevant docs page
+          href={`/${locale}/build/move/move-on-aptos/cryptography#verifying-randomness-from-the-drand-beacon`}
         />
         <FeatureCard
           label={t.feePayerLabel}
           description={t.feePayerDescription}
-          href="" // TODO: Add link to relevant docs page
+          href={`/${locale}/build/sdks/ts-sdk/building-transactions/sponsoring-transactions`}
         />
         <FeatureCard
           label={t.multiSigLabel}
           description={t.multiSigDescription}
-          href="" // TODO: Add link to relevant docs page
+          href={`/${locale}/build/sdks/ts-sdk/building-transactions/multi-agent-transactions`}
         />
         <FeatureCard
           label={t.gasLabel}
           description={t.gasDescription}
-          href="" // TODO: Add link to relevant docs page
+          href={`/${locale}/network/blockchain/learn-about-aptos/gas-txn-fee`}
         />
         <FeatureCard
           label={t.consensusLabel}
           description={t.consensusDescription}
-          href="" // TODO: Add link to relevant docs page
+          href={`/${locale}/network/blockchain/learn-about-aptos/blockchain#consensus`}
         />
         <FeatureCard
           label={t.storageLabel}
           description={t.storageDescription}
-          href="" // TODO: Add link to relevant docs page
+          href={`/${locale}/network/blockchain/learn-about-aptos/blockchain#storage`}
         />
         <FeatureCard
           label={t.networkingLabel}
           description={t.networkingDescription}
-          href="" // TODO: Add link to relevant docs page
+          href={`/${locale}/network/blockchain/learn-about-aptos/node-networks-sync`}
         />
         <FeatureCard
           label={t.mempoolLabel}
           description={t.mempoolDescription}
-          href="" // TODO: Add link to relevant docs page
+          href={`/${locale}/network/blockchain/learn-about-aptos/blockchain#mempool`}
         />
         <FeatureCard
           label={t.stateSyncLabel}
           description={t.stateSyncDescription}
-          href="" // TODO: Add link to relevant docs page
+          href={`/${locale}/network/nodes/configure/state-sync`}
         />
       </div>
     </Section>

--- a/apps/nextra/components/landing/sections/DevelopersSection.tsx
+++ b/apps/nextra/components/landing/sections/DevelopersSection.tsx
@@ -25,7 +25,7 @@ export function DevelopersSection() {
           label={t.developerDiscussionsLabel}
           description={t.developerDiscussionsDescription}
           linkLabel={t.developerDiscussionsLink}
-          href="" // TODO: Add link to relevant docs page
+          href="https://github.com/aptos-labs/aptos-developer-discussions/discussions"
         />
         <DevelopersCard
           label={t.officeHoursLabel}
@@ -37,7 +37,7 @@ export function DevelopersSection() {
           label={t.grantsLabel}
           description={t.grantsDescription}
           linkLabel={t.grantsLink}
-          href="" // TODO: Add link to relevant docs page
+          href="https://aptosfoundation.org/grants"
         />
       </div>
     </Section>

--- a/apps/nextra/components/landing/sections/FooterSection.tsx
+++ b/apps/nextra/components/landing/sections/FooterSection.tsx
@@ -70,17 +70,20 @@ export function FooterSection() {
               links={[
                 {
                   label: t.documentationLink,
-                  href: `${locale}/build/quick-start`,
+                  href: `/${locale}/build/quick-start`,
                 },
                 {
                   label: t.governanceLink,
-                  href: "https://governance.aptosfoundation.org/",
+                  href: `/${locale}/network/blockchain/learn-about-aptos/governance`,
                 },
                 {
                   label: t.networkNumbersLink,
                   href: "https://aptosfoundation.org/#network-numbers",
                 },
-                { label: t.validatorsLink, href: "TODO:" },
+                {
+                  label: t.validatorsLink,
+                  href: `/${locale}/network/blockchain/learn-about-aptos/validator-nodes`,
+                },
                 {
                   label: t.nodeOperationsLink,
                   href: "https://aptos.dev/nodes/nodes-landing/",
@@ -131,7 +134,7 @@ export function FooterSection() {
                 { label: t.netZeroPolicyLink, href: "TODO:" },
                 {
                   label: t.whitePaperLink,
-                  href: "https://aptosfoundation.org/whitepaper",
+                  href: `/${locale}/network/blockchain/aptos-white-paper`,
                 },
                 {
                   label: t.brandLink,

--- a/apps/nextra/components/landing/sections/MoveSection.tsx
+++ b/apps/nextra/components/landing/sections/MoveSection.tsx
@@ -27,19 +27,19 @@ export function MoveSection() {
       coins: {
         label: t.coinsExampleLabel,
         description: t.coinsExampleDescription,
-        href: "", // TODO: Add link to relevant docs page
+        href: `/${locale}/build/standards/aptos-coin`,
         codeSnippet: coinsCodeSnippet,
       },
       objects: {
         label: t.objectsExampleLabel,
         description: t.objectsExampleDescription,
-        href: "", // TODO: Add link to relevant docs page
+        href: `/${locale}/build/standards/aptos-object`,
         codeSnippet: objectsCodeSnippet,
       },
       fungibleAssets: {
         label: t.fungibleAssetsExampleLabel,
         description: t.fungibleAssetsExampleDescription,
-        href: "", // TODO: Add link to relevant docs page
+        href: `/${locale}/build/standards/fungible-asset`,
         codeSnippet: fungibleAssetsCodeSnippet,
       },
     }),

--- a/apps/nextra/components/landing/sections/ToolingSection.tsx
+++ b/apps/nextra/components/landing/sections/ToolingSection.tsx
@@ -41,7 +41,7 @@ export function ToolingSection() {
           }
           label={t.indexerLabel}
           description={t.indexerDescription}
-          href="" // TODO: Add link to relevant docs page
+          href={`/${locale}/build/indexer`}
         />
         <ToolingCard
           illustration={
@@ -70,7 +70,7 @@ export function ToolingSection() {
           }
           label={t.sdkLabel}
           description={t.sdkDescription}
-          href="" // TODO: Add link to relevant docs page
+          href={`/${locale}/build/sdks`}
         />
       </div>
     </Section>


### PR DESCRIPTION
### Description

There are still 4 more hrefs that need to be filled in, but I'm not sure what they should link to. The remaining 4 are marked with `TODO:` so they are easy to find if you use `**/landing` as your files to include glob when searching.

### Checklist

- Do all Lints pass?
  - [] Have you ran `pnpm spellcheck`?
  - [] Have you ran `pnpm fmt`?
  - [] Have you ran `pnpm lint`?
