### PR TITLE
[nextra] Fix some landing links

### DIFF
--- a/apps/docusaurus/docs/standards/fungible-asset.md
+++ b/apps/docusaurus/docs/standards/fungible-asset.md
@@ -497,8 +497,8 @@ To retrieve the balance of the `PrimaryFungibleStore` of the paired FA of coin t
 
 1. Call `paired_metadata<CoinType>()` to obtain the paired FA metadata object address, which is immutable, allowing for storage or caching to enhance performance.
 2. Retrieve the balance of the paired FA:
-    * Call [getCurrentFungibleAssetBalances](https://github.com/aptos-labs/aptos-ts-sdk/blob/c01a26ff899235fac1c31c6cc3fe504b764e5b91/src/api/fungibleAsset.ts#L115);
-    * Alternatively, determine the address of the primary `FungibleStore`, which is deterministic as `sha3_256(32-byte account address | 32-byte metadata object address | 0xFC)`, and obtain the `FungibleStore` resource at this address to fetch the balance. If it is non-zero, this is the final balance of this FA. Otherwise, try to get `ConcurrentFungibleBalance` resource at the same address and get the balance there instead or 0 If `ConcurrentFungibleBalance` does not exist.
+   - Call [getCurrentFungibleAssetBalances](https://github.com/aptos-labs/aptos-ts-sdk/blob/c01a26ff899235fac1c31c6cc3fe504b764e5b91/src/api/fungibleAsset.ts#L115);
+   - Alternatively, determine the address of the primary `FungibleStore`, which is deterministic as `sha3_256(32-byte account address | 32-byte metadata object address | 0xFC)`, and obtain the `FungibleStore` resource at this address to fetch the balance. If it is non-zero, this is the final balance of this FA. Otherwise, try to get `ConcurrentFungibleBalance` resource at the same address and get the balance there instead or 0 If `ConcurrentFungibleBalance` does not exist.
 
 ### Event
 

--- a/apps/nextra/components/landing/sections/FooterSection.tsx
+++ b/apps/nextra/components/landing/sections/FooterSection.tsx
@@ -86,7 +86,7 @@ export function FooterSection() {
                 },
                 {
                   label: t.nodeOperationsLink,
-                  href: "https://aptos.dev/nodes/nodes-landing/",
+                  href: `/${locale}/network/nodes`,
                 },
               ]}
             />
@@ -145,7 +145,7 @@ export function FooterSection() {
                 },
                 {
                   label: t.careersLink,
-                  href: "https://jobs.ashbyhq.com/aptosfoundation",
+                  href: "https://aptosfoundation.org/ecosystem/jobs",
                 },
               ]}
             />
@@ -154,7 +154,7 @@ export function FooterSection() {
 
         <div
           className="
-            flex flex-col sm:flex-row px-5 sm:px-8 py-6 gap-4 sm:gap-6 sm:items-center 
+            flex flex-col sm:flex-row px-5 sm:px-8 py-6 gap-4 sm:gap-6 sm:items-center
             max-sm:border-t border-border-divider body-100 sm:body-200 font-medium
           "
         >


### PR DESCRIPTION
### Description
This changes the careers link to the ecosystem job board, and fixes a link to the old aptos.dev site.

### Checklist

- Do all Lints pass?
  - [] Have you ran `pnpm spellcheck`?
  - [] Have you ran `pnpm fmt`?
  - [] Have you ran `pnpm lint`?
