### PR TITLE
Add manual redirects

### DIFF
--- a/apps/nextra/next.config.mjs
+++ b/apps/nextra/next.config.mjs
@@ -796,6 +796,121 @@ export default withBundleAnalyzer(
         destination: "/en/network/glossary",
         permanent: true,
       },
+      {
+        source: "/indexer/api/example-queries",
+        destination: "/en/build/indexer/common-queries",
+        permanent: true
+      },
+      {
+        source: "/guides/explore-aptos",
+        destination: "/en/network/glossary#aptos-explorer",
+        permanent: true
+      },
+      {
+        source: "/aptos-white-paper/aptos-white-paper-in-korean",
+        destination: "/en/network/blockchain/aptos-white-paper",
+        permanent: true
+      },
+      {
+        source: "/aptos-white-paper/aptos-white-paper-in-japanese",
+        destination: "/en/network/blockchain/aptos-white-paper",
+        permanent: true
+      },
+      {
+        source: "/move/move-on-aptos/gas-profiling",
+        destination: "/en/build/cli/working-with-move-contracts/local-simulation-benchmarking-and-gas-profiling",
+        permanent: true
+      },
+      {
+        source: "/sdks/ts-sdk/sdk-configuration",
+        destination: "/en/build/sdks/ts-sdk",
+        permanent: true
+      },
+      {
+        source: "/sdks/ts-sdk/fetch-data-from-chain",
+        destination: "/en/build/sdks/ts-sdk/fetch-data-via-sdk",
+        permanent: true
+      },
+      {
+        source: "/sdks/ts-sdk/transaction-builder",
+        destination: "/en/build/sdks/ts-sdk/building-transactions",
+        permanent: true
+      },
+      {
+        source: "/sdks/ts-sdk/http-client",
+        destination: "/en/build/sdks/ts-sdk",
+        permanent: true
+      },
+      {
+        source: "/sdks/ts-sdk/move-types",
+        destination: "/en/build/sdks/ts-sdk/building-transactions/bcs-format",
+        permanent: true
+      },
+      {
+        source: "/sdks/ts-sdk/testing",
+        destination: "/en/build/sdks/ts-sdk",
+        permanent: true
+      },
+      {
+        source: "/sdks/ts-sdk/typescript",
+        destination: "/en/build/sdks/ts-sdk",
+        permanent: true
+      },
+      {
+        source: "/tools/aptos-cli/cli-configuration",
+        destination: "/en/build/cli/setup-cli",
+        permanent: true
+      },
+      {
+        source: "/tools/aptos-cli/use-cli/public-network/run-public-network",
+        destination: "/en/build/cli/public-network",
+        permanent: true
+      },
+      {
+        source: "/guides/nfts/aptos-token-overview",
+        destination: "/en/build/smart-contracts/aptos-standards/tokens",
+        permanent: true
+      },
+      {
+        source: "/integration/wallet-adapter-for-dapp",
+        destination: "/en/build/sdks/wallet-adapter/dapp",
+        permanent: true
+      },
+      {
+        source: "/integration/wallet-adapter-for-wallets",
+        destination: "/en/build/sdks/wallet-adapter/wallets",
+        permanent: true
+      },
+      {
+        source: "/integration/aptos-names-service-package",
+        destination: "/en/build/advanced-guides/aptos-name-service",
+        permanent: true
+      },
+      {
+        source: "/nodes/nodes-landing",
+        destination: "/en/network/nodes",
+        permanent: true
+      },
+      {
+        source: "/nodes/validator-node/voter/index",
+        destination: "/en/network/nodes/validator-node/connect-nodes/staking-pool-voter",
+        permanent: true
+      },
+      {
+        source: "/nodes/node-files-all-networks/node-files",
+        destination: "/en/network/nodes/configure/node-files-all-networks/node-files-mainnet",
+        permanent: true
+      },
+      {
+        source: "/move/book/introduction",
+        destination: "/en/build/smart-contracts/learn-move/book",
+        permanent: true
+      },
+      {
+        source: "/move/book/creating-coins",
+        destination: "/en/build/smart-contracts/learn-move/book/move-tutorial",
+        permanent: true
+      }
     ],
   }),
 );

--- a/apps/nextra/next.config.mjs
+++ b/apps/nextra/next.config.mjs
@@ -799,118 +799,121 @@ export default withBundleAnalyzer(
       {
         source: "/indexer/api/example-queries",
         destination: "/en/build/indexer/common-queries",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/guides/explore-aptos",
         destination: "/en/network/glossary#aptos-explorer",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/aptos-white-paper/aptos-white-paper-in-korean",
         destination: "/en/network/blockchain/aptos-white-paper",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/aptos-white-paper/aptos-white-paper-in-japanese",
         destination: "/en/network/blockchain/aptos-white-paper",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/move/move-on-aptos/gas-profiling",
-        destination: "/en/build/cli/working-with-move-contracts/local-simulation-benchmarking-and-gas-profiling",
-        permanent: true
+        destination:
+          "/en/build/cli/working-with-move-contracts/local-simulation-benchmarking-and-gas-profiling",
+        permanent: true,
       },
       {
         source: "/sdks/ts-sdk/sdk-configuration",
         destination: "/en/build/sdks/ts-sdk",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/sdks/ts-sdk/fetch-data-from-chain",
         destination: "/en/build/sdks/ts-sdk/fetch-data-via-sdk",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/sdks/ts-sdk/transaction-builder",
         destination: "/en/build/sdks/ts-sdk/building-transactions",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/sdks/ts-sdk/http-client",
         destination: "/en/build/sdks/ts-sdk",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/sdks/ts-sdk/move-types",
         destination: "/en/build/sdks/ts-sdk/building-transactions/bcs-format",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/sdks/ts-sdk/testing",
         destination: "/en/build/sdks/ts-sdk",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/sdks/ts-sdk/typescript",
         destination: "/en/build/sdks/ts-sdk",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/tools/aptos-cli/cli-configuration",
         destination: "/en/build/cli/setup-cli",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/tools/aptos-cli/use-cli/public-network/run-public-network",
         destination: "/en/build/cli/public-network",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/guides/nfts/aptos-token-overview",
         destination: "/en/build/smart-contracts/aptos-standards/tokens",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/integration/wallet-adapter-for-dapp",
         destination: "/en/build/sdks/wallet-adapter/dapp",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/integration/wallet-adapter-for-wallets",
         destination: "/en/build/sdks/wallet-adapter/wallets",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/integration/aptos-names-service-package",
         destination: "/en/build/advanced-guides/aptos-name-service",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/nodes/nodes-landing",
         destination: "/en/network/nodes",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/nodes/validator-node/voter/index",
-        destination: "/en/network/nodes/validator-node/connect-nodes/staking-pool-voter",
-        permanent: true
+        destination:
+          "/en/network/nodes/validator-node/connect-nodes/staking-pool-voter",
+        permanent: true,
       },
       {
         source: "/nodes/node-files-all-networks/node-files",
-        destination: "/en/network/nodes/configure/node-files-all-networks/node-files-mainnet",
-        permanent: true
+        destination:
+          "/en/network/nodes/configure/node-files-all-networks/node-files-mainnet",
+        permanent: true,
       },
       {
         source: "/move/book/introduction",
         destination: "/en/build/smart-contracts/learn-move/book",
-        permanent: true
+        permanent: true,
       },
       {
         source: "/move/book/creating-coins",
         destination: "/en/build/smart-contracts/learn-move/book/move-tutorial",
-        permanent: true
-      }
+        permanent: true,
+      },
     ],
   }),
 );

--- a/apps/nextra/pages/en/build/sdks/ts-sdk/_meta.tsx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/_meta.tsx
@@ -1,9 +1,9 @@
 export default {
-  "quickstart": {
-    title: "Quickstart"
+  quickstart: {
+    title: "Quickstart",
   },
   "---": {
-    type: "separator"
+    type: "separator",
   },
   "fetch-data-via-sdk": {
     title: "Fetch Data via the TypeScript SDK",


### PR DESCRIPTION
### Description

Adds remaining redirects that can be done by hand. 

### Checklist

Remaining redirects (all of which are for pages which have not been migrated yet):

Tutorials

1. first-transaction.md
2. your-first-nft.md
3. first-coin.md
4. first-fungible-asset.md
5. first-multisig.md

Aptos Community Pages

1. community.md
    1. /community → …
2. external-resources.md
    1. /community/external-resources → …
3. site-updates.md
    1. /community/site-updates → …
4. aptos-style.md
    1. /community/aptos-style → …
5. contributors.md
    1. /community/contributors → …

Build E2E Dapp with Aptos

1. build-e2e-dapp.md
    1. /tutorials/build-e2e-dapp
2. create-a-smart-contract.md
    1. /tutorials/build-e2e-dapp/create-a-smart-contract → …
3. set-up-react-app.md
    1. /tutorials/build-e2e-dapp/set-up-react-app → …
4. add-wallet-support.md
    1. /tutorials/build-e2e-dapp/add-wallet-support → …
5. fetch-data-from-chain.md
    1. /tutorials/build-e2e-dapp/fetch-data-from-chain → …
6. submit-data-to-chain.md
    1. /tutorials/build-e2e-dapp/submit-data-to-chain → …
7. handle-tasks.md
    1. /tutorials/build-e2e-dapp/handle-tasks → …

Other

1. running-a-local-multi-node-network.md
    1. /guides/running-a-local-multi-node-network → … (in the localnet folder)


- Do all Lints pass?
  - [] Have you ran `pnpm spellcheck`?
  - [X] Have you ran `pnpm fmt`?
  - [X] Have you ran `pnpm lint`?
