### PR TITLE
[nextra] fix href absolute path

### DIFF
--- a/apps/nextra/pages/en/build/apis/_meta.tsx
+++ b/apps/nextra/pages/en/build/apis/_meta.tsx
@@ -2,7 +2,7 @@ export default {
   "fullnode-rest-api": "Fullnode REST API",
   "indexer-graphql-api": {
     title: "Indexer GraphQL API",
-    href: "./indexer",
+    href: "/en/build/indexer",
   },
   "aptos-labs-developer-portal": "Developer Portal",
 };


### PR DESCRIPTION
### Description

Relative path redirects change based on the page you're clicking from unfortunately. Setting it to an absolute path instead

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
