### PR TITLE
Update global-storage-operators.md

### DIFF
--- a/apps/docusaurus/docs/aptos-keyless/how-keyless-works.md
+++ b/apps/docusaurus/docs/aptos-keyless/how-keyless-works.md
@@ -80,6 +80,6 @@ The previous flow explained how a dApp can obtain a ZKP from the prover service.
 
 **Step 1**: The dApp obtains an ephemeral signature $\sigma_\mathsf{eph}$ over the TXN from the user. This could be done behind the user’s back, by the dApp itself who might manage the ESK. Or, it could be an actual signing request sent to the user, such as when the ESK is a WebAuthn passkey, which is stored on the user’s trusted hardware.
 
-**Step 2**: The dApp sends the TXN, the ZKP $\pi$, the ephemeral public key $\mathsf{epk}$, and the ephemeral signature $\sigma_\mathsf{eph}$  to the blockchain validators.
+**Step 2**: The dApp sends the TXN, the ZKP $\pi$, the ephemeral public key $\mathsf{epk}$, and the ephemeral signature $\sigma_\mathsf{eph}$ to the blockchain validators.
 
 **Step 3**: To check the TXN is validly-signed, the validators perform several steps: (1) check that $\mathsf{epk}$ has not expired, (2) fetch the user’s address $\mathsf{addr}$ from the TXN, (3) verify the ZKP against $(\mathsf{addr}, \mathsf{epk}, \mathsf{GPK})$, and (4) verify the ephemeral signature $\sigma_\mathsf{eph}$ on the TXN against the $\mathsf{epk}$. If all these checks pass, they can safely execute the TXN.

--- a/apps/docusaurus/docs/move/book/global-storage-operators.md
+++ b/apps/docusaurus/docs/move/book/global-storage-operators.md
@@ -152,7 +152,7 @@ module two_resources {
     struct R2 has key { g: u64 }
 
     fun double_acquires(a: address): u64 acquires R1, R2 {
-        borrow_global<R1>(a).f + borrow_global<R2>.g
+        borrow_global<R1>(a).f + borrow_global<R2>(a).g
     }
 }
 }

--- a/apps/nextra/pages/en/build/smart-contracts/learn-move/_meta.tsx
+++ b/apps/nextra/pages/en/build/smart-contracts/learn-move/_meta.tsx
@@ -10,6 +10,6 @@ export default {
   },
   "first-move-module": {
     title: "Your First Move Module",
-    href: "/en/build/tutorials/first-move-module"
-  }
+    href: "/en/build/tutorials/first-move-module",
+  },
 };

--- a/apps/nextra/pages/en/build/smart-contracts/learn-move/book/global-storage-operators.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/learn-move/book/global-storage-operators.mdx
@@ -153,7 +153,7 @@ module 0x42::two_resources {
   struct R2 has key { g: u64 }
 
   fun double_acquires(a: address): u64 acquires R1, R2 {
-    borrow_global<R1>(a).f + borrow_global<R2>.g
+    borrow_global<R1>(a).f + borrow_global<R2>(a).g
   }
 }
 ```


### PR DESCRIPTION
### Description
Fixed syntax error: added (a) in borrow_global<R2>(a).g
Also fixes `pnpm fmt` issues.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
