### PR TITLE
Add `create-aptos-dapp` doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This will build `apps/nextra` and all local packages it depends on.
 cd apps/nextra
 ```
 
-3. Run development server
+3. Run the development server
 
 ```sh
 pnpm dev
@@ -97,7 +97,7 @@ pnpm dev
 cd apps/docusaurus
 ```
 
-2. Run development server
+2. Run the development server
 
 ```sh
 pnpm start

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ git clone https://github.com/aptos-labs/developer-docs.git
 ## Install deps
 
 You may have to run the following command first if you are on macOS M1 Sonoma or newer
+
 ```sh
 pnpm add node-gyp -g
 ```
@@ -57,7 +58,6 @@ pnpm install
 ## Develop on Nextra (New)
 
 > Note: PLEASE SEE `apps/nextra/README.md` for more details!
-
 
 0. Setup environment
 
@@ -97,13 +97,19 @@ pnpm dev
 cd apps/docusaurus
 ```
 
-2. Build the repository
+2. Run development server
+
+```sh
+pnpm start
+```
+
+3. Build the repository
 
 ```sh
 pnpm build
 ```
 
-3. Navigate to the correct subdirectory
+4. Navigate to the correct subdirectory
 
 ```sh
 pnpm serve

--- a/apps/docusaurus/docs/create-aptos-dapp/faq.md
+++ b/apps/docusaurus/docs/create-aptos-dapp/faq.md
@@ -1,10 +1,9 @@
 ---
 title: "FAQ"
-slug: "faq"
 hidden: false
 ---
 
-# FAQ
+# Create Aptos Dapp FAQ
 
 ## Why do we use `import.meta.env`?
 

--- a/apps/docusaurus/docs/create-aptos-dapp/faq.md
+++ b/apps/docusaurus/docs/create-aptos-dapp/faq.md
@@ -1,0 +1,19 @@
+---
+title: "FAQ"
+slug: "faq"
+hidden: false
+---
+
+# FAQ
+
+## Why do we use `import.meta.env`?
+
+The template is built in a way that there are pages meant to be accessed only on DEV mode and pages that are meant to be accessed also on PROD mode. For example, “create collection” and “my collections” pages are only meant for local development and can only be accessed on DEV mode while the “public mint” page can be accessed on PROD mode. `import.meta.env` is the `Vite` way to know what is the environment the dapp is running on - DEV or PROD.
+
+## I am getting `"Error": "Simulation failed with status: LOOKUP_FAILED"` when trying to publish my move module - what does it mean?
+
+the move module is trying to use a module that is not live yet
+
+## I tried to publish my dapp to a live server but getting `404 error`
+
+might need to update the root route, if you deployed your site to `user-name.github.io/my-repo` then root route should be updated to `my-repo`

--- a/apps/docusaurus/docs/create-aptos-dapp/index.md
+++ b/apps/docusaurus/docs/create-aptos-dapp/index.md
@@ -1,0 +1,68 @@
+---
+title: "Use create-aptos-dapp"
+slug: "index"
+hidden: false
+---
+
+# create-aptos-dapp
+
+`create-aptos-dapp` provides a starter kit for dapp developers to easily bootstrap a dapp on the Aptos network.
+
+## Quick Start
+
+To start with the create-aptos-dapp tool you can simply run this command on your terminal
+
+```bash
+npx create-aptos-dapp
+```
+
+## **What is create-aptos-dapp?**
+
+`create-aptos-dapp` simplifies the initial setup and configuration process, provides a modern development workflow, gives pre-made e2e dapp templates and offers a range of benefits that save time and effort, enabling developers to focus on building dapps on Aptos effectively.
+
+## **Why use create-aptos-dapp?**
+
+- **Template Setup**: `create-aptos-dapp` tool generates a predefined end-to-end dapp templates and configuration files for you. This saves you from manually setting up the basic project structure, which can be time-consuming and error-prone.
+- **Dependencies Management**: `create-aptos-dapp` tool manages project dependencies for you. It generates a `package.json` file with the required packages and their versions, ensuring that your project uses compatible libraries.
+- **Move Folder:** `create-aptos-dapp` generates a `move` folder that includes the basic structure for move modules. It creates a `Move.toml` and `sources` folder with a move module (smart contract) in it.
+- **Best Practices**: `create-aptos-dapp` tool incorporates best practices and structure recommendations to develop for the Aptos network. This ensures that your project starts with a solid foundation.
+- **Built-in Scripts**: `create-aptos-dapp` tool includes built-in scripts for common tasks like initialize default profile, compile move module and publish smart contract to chain. This simplifies common development workflows.
+
+## What tools create-aptos-dapp utilizes?
+
+- React framework
+- Vite development tool
+- shadcn/ui + tailwind for styling
+- Aptos TS SDK
+- Aptos Wallet Adapter
+- Node based Move commands scripts
+
+## How to use create-aptos-dapp?
+
+To create a Aptos dapp, open your terminal, `cd` into the directory you’d like to create the dapp in, and run the following command:
+
+```jsx
+npx create-aptos-dapp
+```
+
+That command will download the tool and start the wizard flow where you can make project selections
+
+```jsx
+// todo add a gif/recording of the wizard flow
+```
+
+Finally, the tool would prompt next steps for you to follow
+
+## Templates
+
+`create-aptos-dapp` provides you with pre-made end-to-end dapp templates, i.e a ready dapp with configurations and a beautiful UI to get you started with creating a dapp on Aptos.
+
+The goals of the templates are to
+
+1. Get you familiar with Aptos Standards by having an end-to-end dapp template examples
+2. Educate you on how to build a dapp on Aptos from the front-end side and the smart contract side and how everything connects together
+3. Provide you with a pre-made templates you can easily configure and deploy into a live server
+
+## [Digital Asset Template](./templates/digital-asset.md)
+
+## [Fungible Asset Template](./templates/fungible-asset.md)

--- a/apps/docusaurus/docs/create-aptos-dapp/index.md
+++ b/apps/docusaurus/docs/create-aptos-dapp/index.md
@@ -6,7 +6,7 @@ hidden: false
 
 # create-aptos-dapp
 
-`create-aptos-dapp` provides a starter kit for dapp developers to easily bootstrap a dapp on the Aptos network.
+`create-aptos-dapp` provides a starter kit for dapp developers to easily bootstrap on the Aptos network.
 
 ## Quick Start
 
@@ -18,15 +18,15 @@ npx create-aptos-dapp
 
 ## **What is create-aptos-dapp?**
 
-`create-aptos-dapp` simplifies the initial setup and configuration process, provides a modern development workflow, gives pre-made e2e dapp templates and offers a range of benefits that save time and effort, enabling developers to focus on building dapps on Aptos effectively.
+`create-aptos-dapp` simplifies the initial setup and configuration process, provides a modern development workflow, gives pre-made e2e dapp templates, and offers a range of benefits that save time and effort. Using `create-aptos-dapp` enables developers to build dapps quicker on Aptos.
 
 ## **Why use create-aptos-dapp?**
 
-- **Template Setup**: `create-aptos-dapp` tool generates a predefined end-to-end dapp templates and configuration files for you. This saves you from manually setting up the basic project structure, which can be time-consuming and error-prone.
-- **Dependencies Management**: `create-aptos-dapp` tool manages project dependencies for you. It generates a `package.json` file with the required packages and their versions, ensuring that your project uses compatible libraries.
-- **Move Folder:** `create-aptos-dapp` generates a `move` folder that includes the basic structure for move modules. It creates a `Move.toml` and `sources` folder with a move module (smart contract) in it.
-- **Best Practices**: `create-aptos-dapp` tool incorporates best practices and structure recommendations to develop for the Aptos network. This ensures that your project starts with a solid foundation.
-- **Built-in Scripts**: `create-aptos-dapp` tool includes built-in scripts for common tasks like initialize default profile, compile move module and publish smart contract to chain. This simplifies common development workflows.
+- **Template Setup**: `create-aptos-dapp` generates predefined end-to-end dapp templates and configuration files for you. It saves manual setup of the project structure, which can be time-consuming and error-prone.
+- **Dependencies Management**: `create-aptos-dapp` manages project dependencies for you. It generates a npm (or pnpm, etc.) package with the required packages. This ensures that the libraries used by your project are compatible.
+- **Move Directory:** `create-aptos-dapp` generates a `move` directory that includes the basic structure for Move modules (smart contracts). Additionally, it adds a basic Move module and associated files.
+- **Best Practices**: `create-aptos-dapp` incorporates best practices and structure recommendations to develop for the Aptos network. This ensures that your project starts with a solid foundation.
+- **Built-in Move Commands**: `create-aptos-dapp` includes built-in commands for common tasks, such as initializing the Move compiler, compiling, and publishing smart contracts on-chain. This abstracts Move development workflows for the average dapp developer.
 
 ## What tools create-aptos-dapp utilizes?
 
@@ -35,23 +35,21 @@ npx create-aptos-dapp
 - shadcn/ui + tailwind for styling
 - Aptos TS SDK
 - Aptos Wallet Adapter
-- Node based Move commands scripts
+- Node based Move commands
 
 ## How to use create-aptos-dapp?
 
 To create a Aptos dapp, open your terminal, `cd` into the directory you’d like to create the dapp in, and run the following command:
 
-```jsx
+```sh
 npx create-aptos-dapp
 ```
 
 That command will download the tool and start the wizard flow where you can make project selections
 
-```jsx
-// todo add a gif/recording of the wizard flow
-```
+<!-- TODO GIF / Video of onboarding flow -->
 
-Finally, the tool would prompt next steps for you to follow
+The tool will respond with next steps
 
 ## Templates
 
@@ -59,10 +57,11 @@ Finally, the tool would prompt next steps for you to follow
 
 The goals of the templates are to
 
-1. Get you familiar with Aptos Standards by having an end-to-end dapp template examples
-2. Educate you on how to build a dapp on Aptos from the front-end side and the smart contract side and how everything connects together
-3. Provide you with a pre-made templates you can easily configure and deploy into a live server
+1. Familiarize users with different Aptos Standards by having an end-to-end dapp template examples.
+2. Educate users on how to build a dapp on Aptos from the front-end layer to the smart contract layer and how everything in-between.
+3. Provide users with pre-made templates to quickly deploy simple dapps
 
-## [Digital Asset Template](./templates/digital-asset.md)
+### Current Templates
 
-## [Fungible Asset Template](./templates/fungible-asset.md)
+- [Digital Asset Template](./templates/digital-asset.md)
+- [Fungible Asset Template](./templates/fungible-asset.md)

--- a/apps/docusaurus/docs/create-aptos-dapp/templates/digital-asset.md
+++ b/apps/docusaurus/docs/create-aptos-dapp/templates/digital-asset.md
@@ -1,0 +1,190 @@
+---
+title: "Digital Asset"
+slug: "digital-asset"
+hidden: false
+---
+
+# Digital Asset Template
+
+A Digital Asset is an NFT stored on a blockchain that uniquely defines ownership of an asset. The Digital Asset template provides an end-to-end NFT minting dapp. With this dapp you can learn how NFTs work on Aptos, how to write a smart contract and a front end that communicates with the contract. In addition, it offers a beautiful pre-made UI for a NFT minting dapp you can quickly adjust and deploy into a live server.
+
+Read more about [Aptos Digital Asset Standard](https://aptos.dev/standards/digital-asset)
+
+The Digital Asset template provides 3 pages
+
+1. Public Mint NFT Page - that page would eventually get deployed into a live server where the public can come to it to mint an NFT
+2. Create Collection Page - where you can create a new NFT collection. This page is not accessible on production.
+3. My Collections Page - where you can view all the collections created under the current move module (i.e smart contract). This page is not accessible on production.
+
+## Public Mint Page
+
+When you first run your app locally with `npm run dev` you would see the public mint page with some data placeholders for content and images. Some of the content can be configured in the `frontend/config.ts` file and some will get pulled from an Aptos server once you configure your collection.
+
+### Config a collection address
+
+To config the collection address and have the public mint page fetch the collection data, you would need to assign the `collection_id` variable in the `frontend/config.ts` file with the collection address you want to use. If you have [created the collection](#create-a-nft-collection-page) with the tool, you should be able to find it on the[ My Collections Page](#my-collections-page).
+
+### Modify static content
+
+Once the collection address has been set up, you can head over to the `frontend/config.ts` file to change and modify any static content on the page. Obviously you can also modify the code itself as you wish.
+
+**How to add static images?**
+
+The public mint page uses static images in the UI. Initialy, the images are imported from the `frontend/assets/placeholder` folder. To use custom images, you should add the image you want to use to the `frontend/assets` folder (under any new folder you want to create) and then import the image as `import MyImage from "@/assets/<my-new-folder>/my-image.png";` in the `frontend/config.ts` file and add it under the section you want to have it.
+
+For example, to update an image in the “Our Team" section - add the image under the `frontend/assets/<my-new-folder>` folder, import the image as `import MyImage from "@/assets/<my-new-folder>/my-image.png";` and change the`img`property in the `ourTeam` section with `MyImage`
+
+**How to modify css/style?**
+
+<!-- TODO -->
+
+## Create a NFT Collection Page
+
+When you first run your app locally with `npm run dev` you would see the Public Mint page, click the “Create Collection” button, that would take you to a page where you can create a new nft collection.
+
+### Publish the Move module
+
+To create a new collection, we need to publish the Move module to chain so we can communicate with it.
+
+The smart contract is built in a way that only the admin or a specific defined account can create a new collections.
+
+Create or find the account you would want to use to create a collection with. If you haven't created an account - simply use a Wallet, for example [Petra](https://petra.app/), to quickly [create an account](https://petra.app/docs/use#create-a-new-account).
+
+1. Run `npm run move:init` - a command to generate a new aptos config file with an account that would be used to publish the move contract. Once you run that command it would:
+
+- Generate a new `.aptos/config.yaml` file that holds the profile with a privateKey, publicKey and account address as well as the network endpoints it uses to make calls to.
+- Configure you development environment and add a `VITE_MODULE_ADDRESS` variable into the `.env` file with the account address of the generated account from the previous step.
+
+2. To set who is the account that has the privilage to create a new collection, head over to the `.env` file and update `VITE_CREATOR_ADDRESS` to be the address of the account you want to use to create the collection with.
+
+3. Run `npm run move:publish`
+
+### Connect a wallet
+
+Once you [published the move module](#publish-the-move-module), you would want to connect your wallet so you can submit transactions. Make sure your Wallet is set to the same account you used in the [previous section](#publish-the-move-module) to publish your move module and that your wallet is set to the same network you selected to work with.
+
+Now you can connect your wallet by clicking on the "Connect Wallet" button on the top right, and start with creating your nft collection.
+
+### Upload Collection Files Data
+
+To create a NFT collection you would need image files and metadata files.
+
+Image files can be of any of the type - `"png", "jpg", "jpeg", "gltf”.` But, make sure all image files have the same file extension. If some images will have `jpeg` extension and some `jpg` extension the upload would fail.
+
+Metadata files are `json` files that hold the Collection data and each of the NFT data.
+
+`create-aptos-dapp` requires you to upload a folder with all the relevant files, a folder structure should be
+
+```jsx
+assets/ // root folder
+ collection.jpeg // the collection image
+ collection.json // the collection metadata
+ images/ // NFT images folder
+  1.jpeg
+  2.jpeg
+  3.jpeg
+ metadatas // NFT metadatas folder
+  1.json
+  2.json
+  3.json
+```
+
+:::note
+Make sure all image files have the same file extension. If some images will have `jpeg` extension and some `jpg` extension the upload would fail.
+:::
+
+<!-- TODO: change ERC-1155 once finish rewriting the NFT standards page  -->
+
+We recommend the developers follow the [ERC-1155 off-chain data](https://eips.ethereum.org/EIPS/eip-1155) schema to format their JSON files. One thing to note, since the image field will be updated with the arweave link after this step, feel free to leave it empty.
+
+Example of `collection.json` file
+
+```jsx
+// collection.json
+{
+  "name": "Aptos NFTs", // Name of the collection.
+  "description": "My NFT Collection on Aptos.", // Descrpition of the collection
+  "image": "to_fill_after_upload", // This is the URL to the image of the collection, we will assign arewave link so feel free to leave it empty
+  "external_url": "https://your_project_url.io" // URL to an external website where the user can also view the image.
+}
+```
+
+Example of a NFT metadata file. The metadata file should have the same name as the relevant image but with a json extension. i.e if the nft image name is `1.jpeg` then a relevant metadata file should be `1.json`
+
+```jsx
+// 1.json
+{
+  "description": "nft 1 in collection", // Descrpition of the NFT
+  "image": "to_fill_after_upload", // This is the URL to the image of the nft, we will assign arewave link so feel free to leave it empty
+  "name": "NFT 1", // Name of the NFT.
+  "external_url": "https://your_project_url.io/1", // URL to an external website where the user can also view the image.
+  "attributes": [ // Object array, where an object should contain trait_type and value fields. value can be a string or a number.
+    {
+      "trait_type": "meme_level",
+      "value": "1"
+    }
+  ]
+}
+
+```
+
+Once you built the folder and you are ready to upload the collection files data, you can use the file input on the UI and choose the folder you want to upload, that would submit the files to [Irys](https://irys.xyz/), a decentralized asset server, that will store your files.
+
+During the upload process, you would need to sign 2 messages to approve file uploading to Irys and maybe be a transfer transaction submission if first need to fund an Irys node to store the files on. Can read more about the process [here](https://docs.irys.xyz/hands-on/tutorials/uploading-nfts).
+
+### Fill out collection details
+
+Next, you would want to fill out some collection details:
+
+- Public mint start date - which defines when the public mint starts
+- Public mint end date - which defines when the public mint ends (can leave it empty if there is no end date)
+- Limit mint per address - which defines the limit of how many NFTs an account can mint
+- (Optional) Royalty Percentage for each NFT - which defines the royalties for nft marketplaces to read and respect when users trade nfts
+- (Optional) Mint fee per NFT - which defines the mint fee cost per nft
+- (Optional) Mint for myself - which defines how many NFTs you would want to mint for yourself once the collection is created
+
+### Submit a create collection transaction
+
+Once everything has filled out, you should be able to click the “Create Collection” button and submit a create collection transaction. The only next step would be to approve the transaction on the wallet.
+
+## My Collections Page
+
+This page displays all the collections that have been created under the current move module. You can click on the contract address, that would redirect you to the Aptos Explorer site where you can see your collection.
+
+When you are ready to use a collection on the Public Mint Page, you would want to copy the collection address and assign it to the `collection_id` on the `frontend/config.ts` file.
+
+Some stats are available on this page, like the amount of minted NFTs and Max Supply of the NFTs.
+
+## How can I take it from here?
+
+Remember, one of the goals of this template is to educate and provide a real life example on how a NFT minting dapp can be on Aptos. We provide some basic concepts and features but there is much more you can do for your dapp.
+
+Some ideas you can look at and support are
+
+1. Allowlist mint stage
+2. A custom flow after someone mints a NFT
+3. Check out our [TS SDK](https://github.com/aptos-labs/aptos-ts-sdk) to see what other [API queries](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/src/api/digitalAsset.ts) you can use to support more features or fetch more datas
+
+## Ready for MAINNET
+
+If you started your dapp on tesnet and you had all the tests and happy with your NFT collection you probably want to get the collection on mainnet.
+
+Creating a collection on mainnet is the same flow as creating it on tesnet but we need to first configure some things.
+
+1. Change the `VITE_APP_NETWORK` value to `mainnet` on the `.env` file
+2. Run `npm run move:init` to initialize an account to work against the Mainnet
+   1. If you already have an account you would like to use to publish the contract under, you can pass its private key when the prompt asks for that.
+   2. If you are generating a new account, you would want to transfer this account some APT on Aptos Mainnet since the tool can’t fund the account when it is against Mainnet.
+3. Check: open `.aptos/config.yaml` file and see that you have a profile under the `mainnet` name. In addition, open the `.env` file and check the `VITE_MODULE_ADDRESS` value is the same as the mainnet profile account account address.
+4. Head over to `scripts/move/publish.js` file, and change the `minter` address to [`0x3c41ff6b5845e0094e19888cba63773591be9de59cafa9e582386f6af15dd490`](https://explorer.aptoslabs.com/object/0x3c41ff6b5845e0094e19888cba63773591be9de59cafa9e582386f6af15dd490/modules/code/mint_stage?network=mainnet) so it would use the Mainnet token-minter address.
+5. Create or get the account you want to create a collection with, open the `.env` file and assign the account address as the `VITE_CREATOR_ADDRESS` value.
+6. Finally, run `npm run move:publish` to publish your move module on Aptos mainnet.
+7. The next step would be to create a collection using this account. Simply follow [the instructions here](#create-a-nft-collection-page)
+
+## Deploy to a live server
+
+`create-aptos-dapp` utilizes Vite as the development tool. To deploy a Vite static site to a live server, you can simply follow [Vite deployment guide](https://vitejs.dev/guide/static-deploy). In a nutshell, you would need to:
+
+1. Run `npm run build` to build a static site
+2. Run `npm run preview` to see how your dapp would look like on a live server
+3. Next, all you need is to deploy your static site to a live server, there are some options for you to choose from and can follow [this guide](https://vitejs.dev/guide/static-deploy#github-pages) on how to use each

--- a/apps/docusaurus/docs/create-aptos-dapp/templates/digital-asset.md
+++ b/apps/docusaurus/docs/create-aptos-dapp/templates/digital-asset.md
@@ -1,75 +1,75 @@
 ---
-title: "Digital Asset"
+title: "Create Aptos Dapp Digital Asset Template"
 slug: "digital-asset"
 hidden: false
 ---
 
-# Digital Asset Template
+# Create Aptos Dapp Digital Asset Template
 
-A Digital Asset is an NFT stored on a blockchain that uniquely defines ownership of an asset. The Digital Asset template provides an end-to-end NFT minting dapp. With this dapp you can learn how NFTs work on Aptos, how to write a smart contract and a front end that communicates with the contract. In addition, it offers a beautiful pre-made UI for a NFT minting dapp you can quickly adjust and deploy into a live server.
+Digital Assets are the NFT standard for Aptos. The Digital Asset template provides an end-to-end NFT minting dapp. With this dapp, you can learn how NFTs work on Aptos, how to write a smart contract and how to write a front end connected to the contract. In addition, it offers a beautiful pre-made UI for a NFT minting dapp users can quickly adjust and deploy into a live server.
 
-Read more about [Aptos Digital Asset Standard](https://aptos.dev/standards/digital-asset)
+Read more about the [Aptos Digital Asset Standard](https://aptos.dev/standards/digital-asset)
 
-The Digital Asset template provides 3 pages
+The Digital Asset template provides 3 pages:
 
-1. Public Mint NFT Page - that page would eventually get deployed into a live server where the public can come to it to mint an NFT
-2. Create Collection Page - where you can create a new NFT collection. This page is not accessible on production.
-3. My Collections Page - where you can view all the collections created under the current move module (i.e smart contract). This page is not accessible on production.
+1. Public Mint NFT Page - A page for the public to mint NFTs.
+2. Create Collection Page - A page for creating new NFT collections. This page is not accessible on production.
+3. My Collections Page - A page to view all the collections created under the current Move module (smart contract). This page is not accessible on production.
 
 ## Public Mint Page
 
-When you first run your app locally with `npm run dev` you would see the public mint page with some data placeholders for content and images. Some of the content can be configured in the `frontend/config.ts` file and some will get pulled from an Aptos server once you configure your collection.
+First run the dapp locally with `npm run dev`. You would see the public mint page with some data placeholders for content and images. Some of the content can be configured in the `frontend/config.ts` file and some will be pulled from an Aptos full node once you configure your collection.
 
-### Config a collection address
+### Configure a collection address
 
-To config the collection address and have the public mint page fetch the collection data, you would need to assign the `collection_id` variable in the `frontend/config.ts` file with the collection address you want to use. If you have [created the collection](#create-a-nft-collection-page) with the tool, you should be able to find it on the[ My Collections Page](#my-collections-page).
+For the public mint page to fetch the collection, you will need to configure the collection address. First, assign the `collection_id` variable in the `frontend/config.ts` file with the collection address. If you have [created a collection](#create-a-nft-collection-page) with the tool, you can find it on the [My Collections Page](#my-collections-page).
 
 ### Modify static content
 
-Once the collection address has been set up, you can head over to the `frontend/config.ts` file to change and modify any static content on the page. Obviously you can also modify the code itself as you wish.
+Once the collection address has been configured, view the `frontend/config.ts` file to change any static content on the page. You can also modify the code itself as you wish.
 
 **How to add static images?**
+The public mint page uses static images in the UI. Initially, the images are imported from the `frontend/assets/placeholder` folder. To use custom images, you should add the image you want to use to the `frontend/assets` folder (under any new folder you want to create) and then import the image as seen below in the `frontend/config.ts` file and add it under the section you want to have it.
 
-The public mint page uses static images in the UI. Initialy, the images are imported from the `frontend/assets/placeholder` folder. To use custom images, you should add the image you want to use to the `frontend/assets` folder (under any new folder you want to create) and then import the image as `import MyImage from "@/assets/<my-new-folder>/my-image.png";` in the `frontend/config.ts` file and add it under the section you want to have it.
+```jsx
+import MyImage from "@/assets/<my-new-folder>/my-image.png";
+```
 
-For example, to update an image in the “Our Team" section - add the image under the `frontend/assets/<my-new-folder>` folder, import the image as `import MyImage from "@/assets/<my-new-folder>/my-image.png";` and change the`img`property in the `ourTeam` section with `MyImage`
-
-**How to modify css/style?**
-
-<!-- TODO -->
+For example, to update an image in the “Our Team" section - add the image under the `frontend/assets/<my-new-folder>` folder, import the image as `import MyImage from "@/assets/<my-new-folder>/my-image.png";` and change the`img`property in the `ourTeam` section with `MyImage`.
 
 ## Create a NFT Collection Page
 
-When you first run your app locally with `npm run dev` you would see the Public Mint page, click the “Create Collection” button, that would take you to a page where you can create a new nft collection.
+When you first running `npm run dev`, you will see the Public Mint page. To create a collection, click the “Create Collection” button, which will navigate you to create a new NFT collection.
 
 ### Publish the Move module
 
-To create a new collection, we need to publish the Move module to chain so we can communicate with it.
+To create a new collection, we will need to publish the Move module on-chain.
 
 The smart contract is built in a way that only the admin or a specific defined account can create a new collections.
 
-Create or find the account you would want to use to create a collection with. If you haven't created an account - simply use a Wallet, for example [Petra](https://petra.app/), to quickly [create an account](https://petra.app/docs/use#create-a-new-account).
+Create or find the account you want to create a collection with. If you haven't created an account - simply use a Wallet, for example [Petra](https://petra.app/), to quickly [create an account](https://petra.app/docs/use#create-a-new-account).
 
-1. Run `npm run move:init` - a command to generate a new aptos config file with an account that would be used to publish the move contract. Once you run that command it would:
+1. Run `npm run move:init` - a command to initialize an account to publish the Move contract. When you run that command it will:
 
-- Generate a new `.aptos/config.yaml` file that holds the profile with a privateKey, publicKey and account address as well as the network endpoints it uses to make calls to.
-- Configure you development environment and add a `VITE_MODULE_ADDRESS` variable into the `.env` file with the account address of the generated account from the previous step.
+   - Generate a new CLI `.aptos/config.yaml` file that holds a profile with the account private key, account address, and network configuration.
+   - Configure your development environment and add a `VITE_MODULE_ADDRESS` variable into the `.env` file with the account address from the previous step.
 
-2. To set who is the account that has the privilage to create a new collection, head over to the `.env` file and update `VITE_CREATOR_ADDRESS` to be the address of the account you want to use to create the collection with.
+2. To set who can create a new collection, edit the `.env` file and update `VITE_CREATOR_ADDRESS` to be the address of the account allowed to create collections.
 
 3. Run `npm run move:publish`
 
 ### Connect a wallet
 
-Once you [published the move module](#publish-the-move-module), you would want to connect your wallet so you can submit transactions. Make sure your Wallet is set to the same account you used in the [previous section](#publish-the-move-module) to publish your move module and that your wallet is set to the same network you selected to work with.
+Once you have [published the move module](#publish-the-move-module), you will need to connect your wallet to submit transactions. Make sure your Wallet is set to the same account you used in the [previous section](#publish-the-move-module) to publish your Move module.
+Also ensure that your wallet is set to the same network you selected to work with (e.g. testnet).
 
-Now you can connect your wallet by clicking on the "Connect Wallet" button on the top right, and start with creating your nft collection.
+Now, you can connect your wallet by clicking on the "Connect Wallet" button at the top right, and start with creating your NFT collection.
 
 ### Upload Collection Files Data
 
-To create a NFT collection you would need image files and metadata files.
+To create a NFT collection you will need image files and metadata files.
 
-Image files can be of any of the type - `"png", "jpg", "jpeg", "gltf”.` But, make sure all image files have the same file extension. If some images will have `jpeg` extension and some `jpg` extension the upload would fail.
+Image files can be of any of the type - `"png", "jpg", "jpeg", "gif”.` But, make sure all image files have the same file extension. If some images have `jpeg` extension and some `jpg` extension, the upload will fail.
 
 Metadata files are `json` files that hold the Collection data and each of the NFT data.
 
@@ -90,7 +90,7 @@ assets/ // root folder
 ```
 
 :::note
-Make sure all image files have the same file extension. If some images will have `jpeg` extension and some `jpg` extension the upload would fail.
+Make sure all image files have the same file extension. If some images will have `jpeg` extension and some `jpg` extension, the upload will fail.
 :::
 
 <!-- TODO: change ERC-1155 once finish rewriting the NFT standards page  -->
@@ -103,19 +103,19 @@ Example of `collection.json` file
 // collection.json
 {
   "name": "Aptos NFTs", // Name of the collection.
-  "description": "My NFT Collection on Aptos.", // Descrpition of the collection
-  "image": "to_fill_after_upload", // This is the URL to the image of the collection, we will assign arewave link so feel free to leave it empty
+  "description": "My NFT Collection on Aptos.", // Description of the collection
+  "image": "to_fill_after_upload", // This is the URL to the image of the collection, we will assign Arweave link so feel free to leave it empty
   "external_url": "https://your_project_url.io" // URL to an external website where the user can also view the image.
 }
 ```
 
-Example of a NFT metadata file. The metadata file should have the same name as the relevant image but with a json extension. i.e if the nft image name is `1.jpeg` then a relevant metadata file should be `1.json`
+Example of an NFT metadata file. The metadata file should have the same name as the relevant image but with a `.json` extension. i.e if the nft image name is `1.jpeg` then a relevant metadata file should be `1.json`
 
 ```jsx
 // 1.json
 {
-  "description": "nft 1 in collection", // Descrpition of the NFT
-  "image": "to_fill_after_upload", // This is the URL to the image of the nft, we will assign arewave link so feel free to leave it empty
+  "description": "nft 1 in collection", // Description of the NFT
+  "image": "to_fill_after_upload", // This is the URL to the image of the NFT, we will assign Arweave link so feel free to leave it empty
   "name": "NFT 1", // Name of the NFT.
   "external_url": "https://your_project_url.io/1", // URL to an external website where the user can also view the image.
   "attributes": [ // Object array, where an object should contain trait_type and value fields. value can be a string or a number.
@@ -128,18 +128,20 @@ Example of a NFT metadata file. The metadata file should have the same name as t
 
 ```
 
-Once you built the folder and you are ready to upload the collection files data, you can use the file input on the UI and choose the folder you want to upload, that would submit the files to [Irys](https://irys.xyz/), a decentralized asset server, that will store your files.
+Once you've built the folder and you are ready to upload the collection files data, you can choose the folder you want to upload through the file input UI.
 
-During the upload process, you would need to sign 2 messages to approve file uploading to Irys and maybe be a transfer transaction submission if first need to fund an Irys node to store the files on. Can read more about the process [here](https://docs.irys.xyz/hands-on/tutorials/uploading-nfts).
+When adding the folder, it submits the files to [Irys](https://irys.xyz/), a decentralized asset server, that will store your files.
+
+During the upload process, you will need to sign two messages to approve file uploading to Irys. Additionally, you may need to fund an Irys node. Read more about the process [here](https://docs.irys.xyz/hands-on/tutorials/uploading-nfts).
 
 ### Fill out collection details
 
-Next, you would want to fill out some collection details:
+Next, you want to fill out some collection details:
 
 - Public mint start date - which defines when the public mint starts
 - Public mint end date - which defines when the public mint ends (can leave it empty if there is no end date)
 - Limit mint per address - which defines the limit of how many NFTs an account can mint
-- (Optional) Royalty Percentage for each NFT - which defines the royalties for nft marketplaces to read and respect when users trade nfts
+- (Optional) Royalty Percentage for each NFT - which defines the royalties for NFT marketplaces to read and respect when users trade nfts
 - (Optional) Mint fee per NFT - which defines the mint fee cost per nft
 - (Optional) Mint for myself - which defines how many NFTs you would want to mint for yourself once the collection is created
 
@@ -149,9 +151,9 @@ Once everything has filled out, you should be able to click the “Create Collec
 
 ## My Collections Page
 
-This page displays all the collections that have been created under the current move module. You can click on the contract address, that would redirect you to the Aptos Explorer site where you can see your collection.
+This page displays all the collections that have been created under the current Move module. You can click on the contract address, which redirects you to the Aptos Explorer site where you can see your collection.
 
-When you are ready to use a collection on the Public Mint Page, you would want to copy the collection address and assign it to the `collection_id` on the `frontend/config.ts` file.
+When you are ready to use a collection on the Public Mint Page, you need to copy the collection address and assign it to the `collection_id` on the `frontend/config.ts` file.
 
 Some stats are available on this page, like the amount of minted NFTs and Max Supply of the NFTs.
 
@@ -159,11 +161,11 @@ Some stats are available on this page, like the amount of minted NFTs and Max Su
 
 Remember, one of the goals of this template is to educate and provide a real life example on how a NFT minting dapp can be on Aptos. We provide some basic concepts and features but there is much more you can do for your dapp.
 
-Some ideas you can look at and support are
+Some ideas you can try are:
 
-1. Allowlist mint stage
-2. A custom flow after someone mints a NFT
-3. Check out our [TS SDK](https://github.com/aptos-labs/aptos-ts-sdk) to see what other [API queries](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/src/api/digitalAsset.ts) you can use to support more features or fetch more datas
+1. Allowlist mint stages
+2. Custom flows after someone mints a NFT (or even token gated experiences)
+3. Check out our [TS SDK](https://github.com/aptos-labs/aptos-ts-sdk) to see what other [API queries](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/src/api/digitalAsset.ts) you can use to support more features and fetch more data.
 
 ## Ready for MAINNET
 

--- a/apps/docusaurus/docs/create-aptos-dapp/templates/digital-asset.md
+++ b/apps/docusaurus/docs/create-aptos-dapp/templates/digital-asset.md
@@ -176,7 +176,7 @@ Creating a collection on mainnet is the same flow as creating it on tesnet but w
    1. If you already have an account you would like to use to publish the contract under, you can pass its private key when the prompt asks for that.
    2. If you are generating a new account, you would want to transfer this account some APT on Aptos Mainnet since the tool can’t fund the account when it is against Mainnet.
 3. Check: open `.aptos/config.yaml` file and see that you have a profile under the `mainnet` name. In addition, open the `.env` file and check the `VITE_MODULE_ADDRESS` value is the same as the mainnet profile account account address.
-4. Head over to `scripts/move/publish.js` file, and change the `minter` address to [`0x3c41ff6b5845e0094e19888cba63773591be9de59cafa9e582386f6af15dd490`](https://explorer.aptoslabs.com/object/0x3c41ff6b5845e0094e19888cba63773591be9de59cafa9e582386f6af15dd490/modules/code/mint_stage?network=mainnet) so it would use the Mainnet token-minter address.
+4. Head over to `scripts/move/publish.js` file, and change the `minter` address to [`0x5ca749c835f44a9a9ff3fb0bec1f8e4f25ee09b424f62058c561ca41ec6bb146`](https://explorer.aptoslabs.com/object/0x5ca749c835f44a9a9ff3fb0bec1f8e4f25ee09b424f62058c561ca41ec6bb146/modules/code/mint_stage?network=mainnet) so it would use the Mainnet token-minter address.
 5. Create or get the account you want to create a collection with, open the `.env` file and assign the account address as the `VITE_CREATOR_ADDRESS` value.
 6. Finally, run `npm run move:publish` to publish your move module on Aptos mainnet.
 7. The next step would be to create a collection using this account. Simply follow [the instructions here](#create-a-nft-collection-page)

--- a/apps/docusaurus/docs/create-aptos-dapp/templates/digital-asset.md
+++ b/apps/docusaurus/docs/create-aptos-dapp/templates/digital-asset.md
@@ -167,18 +167,18 @@ Some ideas you can try are:
 2. Custom flows after someone mints a NFT (or even token gated experiences)
 3. Check out our [TS SDK](https://github.com/aptos-labs/aptos-ts-sdk) to see what other [API queries](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/src/api/digitalAsset.ts) you can use to support more features and fetch more data.
 
-## Ready for MAINNET
+## Ready for Mainnet
 
-If you started your dapp on tesnet and you had all the tests and happy with your NFT collection you probably want to get the collection on mainnet.
+If you started your dapp on testnet, and you are happy with your NFT collection testing, you will want to get the collection on mainnet.
 
-Creating a collection on mainnet is the same flow as creating it on tesnet but we need to first configure some things.
+Creating a collection on mainnet is the same flow as creating on testnet, but we need to change some configuration.
 
-1. Change the `VITE_APP_NETWORK` value to `mainnet` on the `.env` file
-2. Run `npm run move:init` to initialize an account to work against the Mainnet
+1. Change the `VITE_APP_NETWORK` value to `mainnet` in the `.env` file
+2. Run `npm run move:init` to initialize an account to work against Mainnet
    1. If you already have an account you would like to use to publish the contract under, you can pass its private key when the prompt asks for that.
-   2. If you are generating a new account, you would want to transfer this account some APT on Aptos Mainnet since the tool can’t fund the account when it is against Mainnet.
+   2. If you are generating a new account, you need to transfer this account some APT on Aptos Mainnet since the tool can’t fund the account when it is against Mainnet.
 3. Check: open `.aptos/config.yaml` file and see that you have a profile under the `mainnet` name. In addition, open the `.env` file and check the `VITE_MODULE_ADDRESS` value is the same as the mainnet profile account account address.
-4. Head over to `scripts/move/publish.js` file, and change the `minter` address to [`0x5ca749c835f44a9a9ff3fb0bec1f8e4f25ee09b424f62058c561ca41ec6bb146`](https://explorer.aptoslabs.com/object/0x5ca749c835f44a9a9ff3fb0bec1f8e4f25ee09b424f62058c561ca41ec6bb146/modules/code/mint_stage?network=mainnet) so it would use the Mainnet token-minter address.
+4. Edit the `scripts/move/publish.js` file, and change the `minter` address to [`0x5ca749c835f44a9a9ff3fb0bec1f8e4f25ee09b424f62058c561ca41ec6bb146`](https://explorer.aptoslabs.com/object/0x5ca749c835f44a9a9ff3fb0bec1f8e4f25ee09b424f62058c561ca41ec6bb146/modules/code/mint_stage?network=mainnet) so it would use the Mainnet token-minter address.
 5. Create or get the account you want to create a collection with, open the `.env` file and assign the account address as the `VITE_CREATOR_ADDRESS` value.
 6. Finally, run `npm run move:publish` to publish your move module on Aptos mainnet.
 7. The next step would be to create a collection using this account. Simply follow [the instructions here](#create-a-nft-collection-page)

--- a/apps/docusaurus/docs/create-aptos-dapp/templates/fungible-asset.md
+++ b/apps/docusaurus/docs/create-aptos-dapp/templates/fungible-asset.md
@@ -1,0 +1,134 @@
+---
+title: "Fungible Asset"
+slug: "fungible-asset"
+hidden: false
+---
+
+# Fungible Asset Template
+
+The Fungible Asset template provides an end-to-end Fungible Asset minting dapp. With this dapp you can learn how Fungible Assets work on Aptos, how to write a smart contract and a front end that communicates with the contract. In addition, it offers a beautiful pre-made UI for a Fungible Asset minting dapp you can quickly adjust and deploy into a live server.
+
+Read more about [Aptos Fungible Asset Standard](https://aptos.dev/standards/fungible-asset)
+
+The fungible asset template provides 3 pages
+
+1. Public mint page - that page would eventually get deployed into a live server where the public can come to it to mint a fungible asset
+2. Create Asset page - where you can create a new Fungible Asset. This page is not accessible on production.
+3. My Assets page - where you can view all the assets created under the current move module (i.e smart contract). This page is not accessible on production.
+
+## Public Mint Page
+
+When you first run your app locally with `npm run dev` you would see the public mint page with some data placeholders for content and images. Some of the content can be configured in the `frontend/config.ts` file and some will get pulled from an Aptos server once you configure your asset address.
+
+### Config an asset address
+
+To config the asset address and have the public mint page fetch the asset data, you would need to assign the `asset_id` variable in the `frontend/config.ts` file with the FA address you want to use. If you have [created the asset](#create-a-fungible-asset-page) with the tool, you should be able to find it on the [My Assets Page](#my-assets-page).
+
+### Modify static content
+
+Once the asset address has been set up, you can head over to the `frontend/config.ts` file to change and modify any static content on the page. Obviously you can also modify the code itself as you wish.
+
+#### How to add static images?
+
+The public mint page uses static images in the UI. Initialy, the images are imported from the `frontend/assets/placeholder` folder. To use custom images, you should add the image you want to use to the `frontend/assets` folder (under any new folder you want to create) and then import the image as `import MyImage from "@/assets/<my-new-folder>/my-image.png";` in the `frontend/config.ts` file and add it under the section you want to have it.
+
+For example, to update an image in the “Our Team" section - add the image under the `frontend/assets/<my-new-folder>` folder, import the image as `import MyImage from "@/assets/<my-new-folder>/my-image.png";` and change the`img`property in the `ourTeam` section with `MyImage`
+
+#### How to modify css/style?
+
+<!-- TODO -->
+
+## Create a Fungible Asset page
+
+When you first run your app locally with `npm run dev` you would see the Public Mint page, click the “Create Asset” button, that would take you to a page where you can create a new asset.
+
+### Publish the Move module
+
+To create a new asset, we need to publish the Move module to chain so we can communicate with it.
+
+The smart contract is built in a way that only the admin or a specific defined account can create a new asset.
+
+Create or find the account you would want to use to create an asset with. If you haven't created an account - simply use a Wallet, for example [Petra](https://petra.app/), to quickly [create an account](https://petra.app/docs/use#create-a-new-account).
+
+1. Run `npm run move:init` - a command to generate a new aptos config file with an account that would be used to publish the move contract. Once you run that command it would:
+
+- Generate a new `.aptos/config.yaml` file that holds the profile with a privateKey, publicKey and account address as well as the network endpoints it uses to make calls to.
+- Configure you development environment and add a `VITE_MODULE_ADDRESS` variable into the `.env` file with the account address of the generated account from the previous step.
+
+2. To set who is the account that has the privilage to create a new asset, head over to the `.env` file and update `VITE_CREATOR_ADDRESS` to be the address of the account you want to use to create the asset with.
+
+3. Run `npm run move:publish`
+
+### Connect a wallet
+
+Once you [published the move module](#publish-the-move-module), you would want to connect your wallet so you can submit transactions. Make sure your Wallet is set to the same account you used in the [previous section](#publish-the-move-module) to publish your move module and that your wallet is set to the same network you selected to work with.
+
+Now you can connect your wallet by clicking on the "Connect Wallet" button on the top right, and start with creating your asset.
+
+### Upload an Asset File
+
+To create an asset you would need an image for the asset.
+
+The image file can be of any of the type - `"png", "jpg", "jpeg", "gltf”.`
+
+To upload the asset image, you can use the file input on the UI and choose the file you want to upload, that would submit the file to [Irys](https://irys.xyz/), a decentralized asset server, that will store your file.
+
+During the upload process, you would need to sign a message to approve file uploading to Irys and maybe a transfer transaction submission if first need to fund an Irys node to store the files on. Can read more about the process [here](https://docs.irys.xyz/hands-on/tutorials/uploading-nfts).
+
+### Fill out asset details
+
+Next, you would want to fill out some asset details:
+
+- Asset Name - which defines asset name
+- Asset Symbol - which defines the asset symbol
+- Max Supply - which defines the max supply of the asset
+- Mint fee per fungible asset - which defines the mint fee cost per asset
+- Max mint per account - which defines the maximum amount of assets an account can mint
+- Decimal - which defines the number of decimals of the asset
+- Project URL - the project URL
+- (Optional) Mint for myself - which defines how many assets you would want to mint for yourself once the asset is created
+
+### Submit a create asset transaction
+
+Once everything has filled out, you should be able to click the “Create Asset” button and submit a create asset transaction. The only next step would be to approve the transaction on the wallet.
+
+## My Assets Page
+
+This page displays all the assets that have been created under the current move module. You can click on the FA address, that would redirect you to the Aptos Explorer site where you can see your asset.
+
+When you are ready to use an asset on the Public Mint Page, you would want to copy the FA address and assign it to the `asset_id` on the `frontend/config.ts` file.
+
+Some stats are available on this page, like the max supply of the asset and the number of asset minted.
+
+## How can I take it from here?
+
+Remember, one of the goals of this template is to educate and provide a real life example on how a Fungible Asset minting dapp can be on Aptos. We provide some basic concepts and features but there is much more you can do for your dapp.
+
+Some ideas you can look at and support are
+
+1. Allowlist mint stage
+2. A custom flow after someone mints an Asset
+3. Check out our [TS SDK](https://github.com/aptos-labs/aptos-ts-sdk) to see what other [API queries](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/src/api/digitalAsset.ts) you can use to support more features or fetch more datas
+
+## Ready for MAINNET
+
+If you started your dapp on tesnet and you had all the tests and happy with your Fungible Asset you probably want to get the asset on mainnet.
+
+Creating an asset on mainnet is the same flow as creating it on tesnet but we need to first configure some things.
+
+1. Change the `VITE_APP_NETWORK` value to `mainnet` on the `.env` file
+2. Run `npm run move:init` to initialize an account to work against the Mainnet
+   1. If you already have an account you would like to use to publish the contract under, you can pass its private key when the tool asks for that.
+   2. If you are generating a new account, you would want to transfer this account some APT on Aptos Mainnet since the tool can’t fund the account when it is against Mainnet.
+3. Check: open `.aptos/config.yaml` file and see that you have a profile under the `mainnet` name. In addition, open the `.env` file and check the `VITE_MODULE_ADDRESS` value is the same as the mainnet profile account account address.
+4. Create or get the account you want to create a collection with, open the `.env` file and assign the account address as the `VITE_CREATOR_ADDRESS` value.
+5. Finally, run `npm run move:publish` to publish your move module on Aptos mainnet.
+6. The next step would be to create an asset using this account. Simply follow [https://www.notion.so/aptoslabs/WIP-create-aptos-dapp-doc-41982c9e40e049cd962e1e0e42d0bdbd?pvs=4#20ef513460fb4452aedbece1a7523425](https://www.notion.so/WIP-create-aptos-dapp-dev-doc-41982c9e40e049cd962e1e0e42d0bdbd?pvs=21)
+
+## Deploy to a live server
+
+`create-aptos-dapp` utilizes Vite as the development tool. To deploy a Vite static site to a live server, you can simply follow [Vite deployment guide](https://vitejs.dev/guide/static-deploy). In a nutshell, you would need to:
+
+1. Run `npm run build` to build a static site
+2. Run `npm run preview` to see how your dapp would look like on a live server
+3. Next, all you need is to deploy your static site to a live server, there are some options for you to choose from and can follow [this guide](https://vitejs.dev/guide/static-deploy#github-pages) on how to use each

--- a/apps/docusaurus/docs/create-aptos-dapp/templates/fungible-asset.md
+++ b/apps/docusaurus/docs/create-aptos-dapp/templates/fungible-asset.md
@@ -1,83 +1,85 @@
 ---
-title: "Fungible Asset"
-slug: "fungible-asset"
+title: "Create Aptos Dapp Fungible Asset Template"
 hidden: false
 ---
 
-# Fungible Asset Template
+# Create Aptos Dapp Fungible Asset Template
 
-The Fungible Asset template provides an end-to-end Fungible Asset minting dapp. With this dapp you can learn how Fungible Assets work on Aptos, how to write a smart contract and a front end that communicates with the contract. In addition, it offers a beautiful pre-made UI for a Fungible Asset minting dapp you can quickly adjust and deploy into a live server.
+The Fungible Asset template provides an end-to-end Fungible Asset minting dapp. With this dapp, you can learn how Fungible Assets work on Aptos, how to write a smart contract and how to write a front end connected to the contract. In addition, it offers a beautiful pre-made UI for a Fungible Asset minting dapp users can quickly adjust and deploy into a live server.
 
-Read more about [Aptos Fungible Asset Standard](https://aptos.dev/standards/fungible-asset)
+Read more about the [Aptos Fungible Asset Standard](https://aptos.dev/standards/fungible-asset)
 
-The fungible asset template provides 3 pages
+The Fungible Asset template provides 3 pages:
 
-1. Public mint page - that page would eventually get deployed into a live server where the public can come to it to mint a fungible asset
-2. Create Asset page - where you can create a new Fungible Asset. This page is not accessible on production.
-3. My Assets page - where you can view all the assets created under the current move module (i.e smart contract). This page is not accessible on production.
+1. Public Mint Fungible Asset Page - A page for the public to mint Fungible Assets.
+2. Create Fungible Asset page - A page for creating new asset. This page is not accessible on production.
+3. My Fungible Assets page - A page to view all the assets created under the current Move module (smart contract). This page is not accessible on production.
 
 ## Public Mint Page
 
-When you first run your app locally with `npm run dev` you would see the public mint page with some data placeholders for content and images. Some of the content can be configured in the `frontend/config.ts` file and some will get pulled from an Aptos server once you configure your asset address.
+First run the dapp locally with `npm run dev`. You would see the public mint page with some data placeholders for content and images. Some of the content can be configured in the `frontend/config.ts` file and some will be pulled from an Aptos full node once you configure your collection.
 
-### Config an asset address
+### Configure an asset address
 
-To config the asset address and have the public mint page fetch the asset data, you would need to assign the `asset_id` variable in the `frontend/config.ts` file with the FA address you want to use. If you have [created the asset](#create-a-fungible-asset-page) with the tool, you should be able to find it on the [My Assets Page](#my-assets-page).
+For the public mint page to fetch the asset, you will need to configure the asset address. First, assign the `asset_id` variable in the `frontend/config.ts` file with the asset address. If you have [created the asset](#create-a-fungible-asset-page) with the tool, you should be able to find it on the [My Assets Page](#my-assets-page).
 
 ### Modify static content
 
-Once the asset address has been set up, you can head over to the `frontend/config.ts` file to change and modify any static content on the page. Obviously you can also modify the code itself as you wish.
+Once the asset address has been configured, view the `frontend/config.ts` file to change any static content on the page. You can also modify the code itself as you wish.
 
 #### How to add static images?
 
-The public mint page uses static images in the UI. Initialy, the images are imported from the `frontend/assets/placeholder` folder. To use custom images, you should add the image you want to use to the `frontend/assets` folder (under any new folder you want to create) and then import the image as `import MyImage from "@/assets/<my-new-folder>/my-image.png";` in the `frontend/config.ts` file and add it under the section you want to have it.
+The public mint page uses static images in the UI. Initially, the images are imported from the `frontend/assets/placeholder` folder. To use custom images, you should add the image you want to use to the `frontend/assets` folder (under any new folder you want to create) and then import the image as seen below in the `frontend/config.ts` file and add it under the section you want to have it.
 
-For example, to update an image in the “Our Team" section - add the image under the `frontend/assets/<my-new-folder>` folder, import the image as `import MyImage from "@/assets/<my-new-folder>/my-image.png";` and change the`img`property in the `ourTeam` section with `MyImage`
+```jsx
+import MyImage from "@/assets/<my-new-folder>/my-image.png";
+```
 
-#### How to modify css/style?
-
-<!-- TODO -->
+For example, to update an image in the “Our Team" section - add the image under the `frontend/assets/<my-new-folder>` folder, import the image as `import MyImage from "@/assets/<my-new-folder>/my-image.png";` and change the`img`property in the `ourTeam` section with `MyImage`.
 
 ## Create a Fungible Asset page
 
-When you first run your app locally with `npm run dev` you would see the Public Mint page, click the “Create Asset” button, that would take you to a page where you can create a new asset.
+When you first running `npm run dev`, you will see the Public Mint page. To create an asset, click the “Create Asset" button, which will navigate you to create a new fungible asset.
 
 ### Publish the Move module
 
-To create a new asset, we need to publish the Move module to chain so we can communicate with it.
+To create a new asset, we will need to publish the Move module on-chain.
 
 The smart contract is built in a way that only the admin or a specific defined account can create a new asset.
 
-Create or find the account you would want to use to create an asset with. If you haven't created an account - simply use a Wallet, for example [Petra](https://petra.app/), to quickly [create an account](https://petra.app/docs/use#create-a-new-account).
+Create or find the account you want to create an asset with. If you haven't created an account - simply use a Wallet, for example [Petra](https://petra.app/), to quickly [create an account](https://petra.app/docs/use#create-a-new-account).
 
-1. Run `npm run move:init` - a command to generate a new aptos config file with an account that would be used to publish the move contract. Once you run that command it would:
+1. Run `npm run move:init` - a command to initialize an account to publish the Move contract. When you run that command it will:
 
-- Generate a new `.aptos/config.yaml` file that holds the profile with a privateKey, publicKey and account address as well as the network endpoints it uses to make calls to.
-- Configure you development environment and add a `VITE_MODULE_ADDRESS` variable into the `.env` file with the account address of the generated account from the previous step.
+   - Generate a new CLI `.aptos/config.yaml` file that holds a profile with the account private key, account address, and network configuration.
+   - Configure your development environment and add a `VITE_MODULE_ADDRESS` variable into the `.env` file with the account address from the previous step.
 
-2. To set who is the account that has the privilage to create a new asset, head over to the `.env` file and update `VITE_CREATOR_ADDRESS` to be the address of the account you want to use to create the asset with.
+2. To set who can create a new asset, edit the `.env` file and update `VITE_CREATOR_ADDRESS` to be the address of the account allowed to create assets.
 
 3. Run `npm run move:publish`
 
 ### Connect a wallet
 
-Once you [published the move module](#publish-the-move-module), you would want to connect your wallet so you can submit transactions. Make sure your Wallet is set to the same account you used in the [previous section](#publish-the-move-module) to publish your move module and that your wallet is set to the same network you selected to work with.
+Once you have [published the move module](#publish-the-move-module), you will need to connect your wallet to submit transactions. Make sure your Wallet is set to the same account you used in the [previous section](#publish-the-move-module) to publish your Move module.
+Also ensure that your wallet is set to the same network you selected to work with (e.g. testnet).
 
-Now you can connect your wallet by clicking on the "Connect Wallet" button on the top right, and start with creating your asset.
+Now, you can connect your wallet by clicking on the "Connect Wallet" button at the top right, and start with creating your asset.
 
 ### Upload an Asset File
 
-To create an asset you would need an image for the asset.
+To create an asset you will need an image file.
 
-The image file can be of any of the type - `"png", "jpg", "jpeg", "gltf”.`
+Image file can be of any of the type - `"png", "jpg", "jpeg", "gif”.`
 
-To upload the asset image, you can use the file input on the UI and choose the file you want to upload, that would submit the file to [Irys](https://irys.xyz/), a decentralized asset server, that will store your file.
+Once you are ready to upload the asset image file, you can choose the file you want to upload through the file input UI.
 
-During the upload process, you would need to sign a message to approve file uploading to Irys and maybe a transfer transaction submission if first need to fund an Irys node to store the files on. Can read more about the process [here](https://docs.irys.xyz/hands-on/tutorials/uploading-nfts).
+When adding the file, it submits the it to [Irys](https://irys.xyz/), a decentralized asset server, that will store your files.
+
+During the upload process, you will need to sign a message to approve file uploading to Irys. Additionally, you may need to fund an Irys node. Read more about the process [here](https://docs.irys.xyz/hands-on/tutorials/uploading-nfts).
 
 ### Fill out asset details
 
-Next, you would want to fill out some asset details:
+Next, you want to fill out some asset details:
 
 - Asset Name - which defines asset name
 - Asset Symbol - which defines the asset symbol
@@ -94,9 +96,9 @@ Once everything has filled out, you should be able to click the “Create Asset�
 
 ## My Assets Page
 
-This page displays all the assets that have been created under the current move module. You can click on the FA address, that would redirect you to the Aptos Explorer site where you can see your asset.
+This page displays all the assets that have been created under the current Move module. You can click on the asset address, which redirects you to the Aptos Explorer site where you can see your asset.
 
-When you are ready to use an asset on the Public Mint Page, you would want to copy the FA address and assign it to the `asset_id` on the `frontend/config.ts` file.
+When you are ready to use an asset on the Public Mint Page, you need to copy the asset address and assign it to the `asset_id` on the `frontend/config.ts` file.
 
 Some stats are available on this page, like the max supply of the asset and the number of asset minted.
 
@@ -104,11 +106,11 @@ Some stats are available on this page, like the max supply of the asset and the 
 
 Remember, one of the goals of this template is to educate and provide a real life example on how a Fungible Asset minting dapp can be on Aptos. We provide some basic concepts and features but there is much more you can do for your dapp.
 
-Some ideas you can look at and support are
+Some ideas you can try are:
 
-1. Allowlist mint stage
-2. A custom flow after someone mints an Asset
-3. Check out our [TS SDK](https://github.com/aptos-labs/aptos-ts-sdk) to see what other [API queries](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/src/api/digitalAsset.ts) you can use to support more features or fetch more datas
+1. Allowlist mint stages
+2. Custom flows after someone mints an asset (or even token gated experiences)
+3. Check out our [TS SDK](https://github.com/aptos-labs/aptos-ts-sdk) to see what other [API queries](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/src/api/digitalAsset.ts) you can use to support more features and fetch more data.
 
 ## Ready for MAINNET
 

--- a/apps/docusaurus/docs/create-aptos-dapp/templates/fungible-asset.md
+++ b/apps/docusaurus/docs/create-aptos-dapp/templates/fungible-asset.md
@@ -112,18 +112,18 @@ Some ideas you can try are:
 2. Custom flows after someone mints an asset (or even token gated experiences)
 3. Check out our [TS SDK](https://github.com/aptos-labs/aptos-ts-sdk) to see what other [API queries](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/src/api/digitalAsset.ts) you can use to support more features and fetch more data.
 
-## Ready for MAINNET
+## Ready for Mainnet
 
-If you started your dapp on tesnet and you had all the tests and happy with your Fungible Asset you probably want to get the asset on mainnet.
+If you started your dapp on testnet, and you are happy with your asset testing, you will want to get the asset on mainnet.
 
-Creating an asset on mainnet is the same flow as creating it on tesnet but we need to first configure some things.
+Creating a asset on mainnet is the same flow as creating on testnet, but we need to change some configuration.
 
-1. Change the `VITE_APP_NETWORK` value to `mainnet` on the `.env` file
-2. Run `npm run move:init` to initialize an account to work against the Mainnet
-   1. If you already have an account you would like to use to publish the contract under, you can pass its private key when the tool asks for that.
-   2. If you are generating a new account, you would want to transfer this account some APT on Aptos Mainnet since the tool can’t fund the account when it is against Mainnet.
+1. Change the `VITE_APP_NETWORK` value to `mainnet` in the `.env` file
+2. Run `npm run move:init` to initialize an account to work against Mainnet
+   1. If you already have an account you would like to use to publish the contract under, you can pass its private key when the prompt asks for that.
+   2. If you are generating a new account, you need to transfer this account some APT on Aptos Mainnet since the tool can’t fund the account when it is against Mainnet.
 3. Check: open `.aptos/config.yaml` file and see that you have a profile under the `mainnet` name. In addition, open the `.env` file and check the `VITE_MODULE_ADDRESS` value is the same as the mainnet profile account account address.
-4. Create or get the account you want to create a collection with, open the `.env` file and assign the account address as the `VITE_CREATOR_ADDRESS` value.
+4. Create or get the account you want to create a asset with, open the `.env` file and assign the account address as the `VITE_CREATOR_ADDRESS` value.
 5. Finally, run `npm run move:publish` to publish your move module on Aptos mainnet.
 6. The next step would be to create an asset using this account. Simply follow [https://www.notion.so/aptoslabs/WIP-create-aptos-dapp-doc-41982c9e40e049cd962e1e0e42d0bdbd?pvs=4#20ef513460fb4452aedbece1a7523425](https://www.notion.so/WIP-create-aptos-dapp-dev-doc-41982c9e40e049cd962e1e0e42d0bdbd?pvs=21)
 

--- a/apps/docusaurus/docusaurus.config.ts
+++ b/apps/docusaurus/docusaurus.config.ts
@@ -149,6 +149,10 @@ const themeConfig: Preset.ThemeConfig = {
             to: "/sdks/index",
           },
           {
+            label: "create-aptos-dapp",
+            to: "/create-aptos-dapp/index",
+          },
+          {
             label: "Aptos CLI",
             to: "/tools/aptos-cli",
           },

--- a/apps/docusaurus/src/components/sidebars.ts
+++ b/apps/docusaurus/src/components/sidebars.ts
@@ -387,6 +387,26 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: "category",
+      label: "create-aptos-dapp",
+      collapsible: true,
+      collapsed: true,
+      link: { type: "doc", id: "create-aptos-dapp/index" },
+      items: [
+        {
+          type: "category",
+          label: "Templates",
+          collapsible: true,
+          collapsed: true,
+          items: [
+            "create-aptos-dapp/templates/digital-asset",
+            "create-aptos-dapp/templates/fungible-asset",
+          ],
+        },
+        "create-aptos-dapp/faq",
+      ],
+    },
+    {
+      type: "category",
       label: "Aptos CLI",
       collapsible: true,
       collapsed: true,


### PR DESCRIPTION
### Description
This PR adds a documentation for `create-aptos-dapp`.
Some minor content is missing and will add it later but wanted to get this out to have
1. A review on the page structure
2. English check

What is the status with the new doc site? should we copy the same content to there also? if so, once it looks good, I can copy everything to nextra

Questions:
I tried to use a nested list but couldn't find a way to display it nicely  https://github.com/aptos-labs/developer-docs/pull/438/files#diff-76263fbad0317ff827afa03f31f953912a8b4336a2c031276085a7d59e2c3ad6R53-R56
### Checklist

- Do all Lints pass?
  - [ ] Have you ran `pnpm spellcheck`?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
