### PR TITLE
Fix create-aptos-dapp templates

### DIFF
--- a/apps/nextra/pages/en/build/create-aptos-dapp/templates/digital-asset.mdx
+++ b/apps/nextra/pages/en/build/create-aptos-dapp/templates/digital-asset.mdx
@@ -20,7 +20,7 @@ The Digital Asset template provides 3 pages:
 
 First, run the dapp locally with `npm run dev`. You would see the public mint page with some data placeholders for content and images. Some of the content can be configured in the `frontend/config.ts` file and some will be pulled from an Aptos full node once you configure your collection.
 
-```bash npm2yarn
+```bash 
 npm run dev
 ```
 
@@ -47,7 +47,7 @@ For example, to update an image in the "Our Team" section - add the image under 
 
 When you first run `npm run dev`, you will see the Public Mint page. To create a collection, click the "Create Collection" button, which will navigate you to create a new NFT collection.
 
-```bash npm2yarn
+```bash 
 npm run dev
 ```
 
@@ -60,7 +60,7 @@ The smart contract is built in a way that only the admin or a specific defined a
 Create or find the account you want to create a collection with. If you haven't created an account - simply use a Wallet, for example [Petra](https://petra.app/), to quickly [create an account](https://petra.app/docs/use#create-a-new-account).
 
 1. Run `npm run move:init` - a command to initialize an account to publish the Move contract. When you run that command it will:
-```bash npm2yarn
+```bash 
 npm run move:init
 ```
    - Generate a new CLI `.aptos/config.yaml` file that holds a profile with the account private key, account address, and network configuration.
@@ -69,9 +69,6 @@ npm run move:init
 
 3. Run `npm run move:publish` to publish the contract. When you run that command it will:
 
-```bash npm2yarn
-npm run move:publish
-```
    - Save the module address to VITE_MODULE_ADDRESS in the `.env` file.
 
 ### Upgrade the Move module

--- a/apps/nextra/pages/en/build/create-aptos-dapp/templates/fungible-asset.mdx
+++ b/apps/nextra/pages/en/build/create-aptos-dapp/templates/fungible-asset.mdx
@@ -18,7 +18,7 @@ The Fungible Asset template provides 3 pages:
 
 First run the dapp locally with `npm run dev`. You would see the public mint page with some data placeholders for content and images. Some of the content can be configured in the `frontend/config.ts` file and some will be pulled from an Aptos full node once you configure your collection.
 
-```bash npm2yarn
+```bash 
 npm run dev
 ```
 
@@ -44,7 +44,7 @@ For example, to update an image in the "Our Team" section - add the image under 
 
 When first running `npm run dev`, you will see the Public Mint page. To create an asset, click the "Create Asset" button, which will navigate you to create a new fungible asset.
 
-```bash npm2yarn
+```bash 
 npm run dev
 ```
 
@@ -57,7 +57,7 @@ The smart contract is built in a way that only the admin or a specific defined a
 Create or find the account you want to create an asset with. If you haven't created an account - simply use a Wallet, for example [Petra](https://petra.app/), to quickly [create an account](https://petra.app/docs/use#create-a-new-account).
 
 1. Run `npm run move:init` - a command to initialize an account to publish the Move contract. When you run that command it will:
-```bash npm2yarn
+```bash 
 npm run move:init
 ```
    - Generate a new CLI `.aptos/config.yaml` file that holds a profile with the account private key, account address, and network configuration.
@@ -66,7 +66,7 @@ npm run move:init
 
 3. Run `npm run move:publish` to publish the contract. When you run that command it will:
 
-```bash npm2yarn
+```bash
 npm run move:publish
 ```
    - Save the module address to VITE_MODULE_ADDRESS in the `.env` file.


### PR DESCRIPTION
### Description
- Removes unneeded code block
- Remove use of `yarn/pnpm/bun` as the tool currently only supports `npm`
### Checklist

- Do all Lints pass?
  - [ ] Have you ran `pnpm spellcheck`?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
