### PR TITLE
[move-reference] Put move reference in an iframe from the legacy site

### DIFF
--- a/apps/nextra/components/framework-reference/index.tsx
+++ b/apps/nextra/components/framework-reference/index.tsx
@@ -1,0 +1,11 @@
+export function AptosFrameworkReference() {
+  return (
+    <iframe
+      className="w-full"
+      height="100%"
+      src={`https://legacy.aptos.dev/reference/move`}
+      title="Move Reference"
+      frameBorder="0"
+    ></iframe>
+  );
+}

--- a/apps/nextra/components/index.tsx
+++ b/apps/nextra/components/index.tsx
@@ -6,3 +6,4 @@ export * from "./beta-notice";
 export * from "./codeblock";
 export * from "./remote-codeblock";
 export * from "./api-reference";
+export * from "./framework-reference";

--- a/apps/nextra/pages/en/build/smart-contracts/_meta.tsx
+++ b/apps/nextra/pages/en/build/smart-contracts/_meta.tsx
@@ -87,7 +87,10 @@ export default {
   },
   "move-reference": {
     title: "Move Reference",
-    href: "https://legacy.aptos.dev/reference/move",
+    theme: {
+      toc: false,
+      layout: "full",
+    },
   },
   "error-codes": {
     title: "Error Codes",

--- a/apps/nextra/pages/en/build/smart-contracts/move-reference.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/move-reference.mdx
@@ -1,0 +1,5 @@
+import { MoveReference, AptosFrameworkReference } from '@components/index';
+
+# Move Reference
+
+<AptosFrameworkReference />


### PR DESCRIPTION
### Description
We can host the move reference on a friendlier site, and just iframe it in since the experience seems to be really rough for integrating it into Nextra.

This is an alternative to sending people away from the nextra site.

### Checklist

- Do all Lints pass?
  - [ ] Have you ran `pnpm spellcheck`?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
