### PR TITLE
[Nodes] Add small warning to snapshot bootstrapping

### DIFF
--- a/apps/nextra/pages/en/network/nodes/bootstrap-fullnode/bootstrap-fullnode.mdx
+++ b/apps/nextra/pages/en/network/nodes/bootstrap-fullnode/bootstrap-fullnode.mdx
@@ -9,6 +9,12 @@ import { Callout, Steps } from 'nextra/components';
 This document describes how to bootstrap an Aptos node quickly using a snapshot. This can be done on all node types,
 including validators, VFNs and PFNs.
 
+<Callout type="warning">
+**Indexer snapshots**<br />
+The snapshots provided by the community do not provide indexer support. If you are bootstrapping an indexer node,
+you will need to do so by using a [backup](./aptos-db-restore.mdx).
+</Callout>
+
 Although you can bootstrap a new node using [state sync](../configure/state-sync.mdx), this might not be the fastest approach after the network
 has been running for a while; it can either take too much time, or it won't be able to fetch all the required data since
 other nodes may have already pruned their ledger history. To avoid this, you can bootstrap your node using an


### PR DESCRIPTION
### Description
This PR adds a small warning to the `Bootstrap from a Snapshot` page (specifically that indexer snapshotting is not supported).

### Checklist

- Do all Lints pass?
  - [ ] Have you ran `pnpm spellcheck`?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
