### PR TITLE
Fixed create_named_address argument from caller_address to caller

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/objects/creating-objects.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/objects/creating-objects.mdx
@@ -45,7 +45,7 @@ module my_addr::object_playground {
 
   entry fun create_my_object(caller: &signer) {
     let caller_address = signer::address_of(caller);
-    let constructor_ref = object::create_named_object(caller_address, NAME);
+    let constructor_ref = object::create_named_object(caller, NAME);
     // ...
   }
 


### PR DESCRIPTION
### Description
The first argument passed in function 'create_named_address' is incorrect. It should be &signer.
### Checklist

- Do all Lints pass?
  - [ ] Have you ran `pnpm spellcheck`?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
