### PR TITLE
[redirects] Fix redirect loop for /move/book/summary

### DIFF
--- a/apps/nextra/next.config.mjs
+++ b/apps/nextra/next.config.mjs
@@ -1128,7 +1128,7 @@ export default withBundleAnalyzer(
       },
       {
         source: "/move/book/summary",
-        destination: "/en/build/smart-contracts/book/SUMMARY",
+        destination: "/en/build/smart-contracts/book",
         permanent: true,
       },
       {


### PR DESCRIPTION
### Description

Fix redirect loop for `https://aptos.dev/move/book/summary/` which is the [top result on google](https://www.google.com/search?q=aptos+move+book&oq=aptos+move+book&gs_lcrp=EgZjaHJvbWUqBggAEEUYOzIGCAAQRRg7MgYIARBFGDwyBggCEEUYPDIGCAMQLhhA0gEIMTQzNWowajGoAgCwAgA&sourceid=chrome&ie=UTF-8) for "aptos move book"

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
