### PR TITLE
change asset_id -> fa_address

### DIFF
--- a/apps/docusaurus/docs/create-aptos-dapp/templates/fungible-asset.md
+++ b/apps/docusaurus/docs/create-aptos-dapp/templates/fungible-asset.md
@@ -21,7 +21,7 @@ First run the dapp locally with `npm run dev`. You would see the public mint pag
 
 ### Configure an asset address
 
-For the public mint page to fetch the asset, you will need to configure the asset address. First, assign the `asset_id` variable in the `frontend/config.ts` file with the asset address. If you have [created the asset](#create-a-fungible-asset-page) with the tool, you should be able to find it on the [My Assets Page](#my-assets-page).
+For the public mint page to fetch the asset, you will need to configure the asset address. First, assign the `fa_address` variable in the `frontend/config.ts` file with the asset address. If you have [created the asset](#create-a-fungible-asset-page) with the tool, you should be able to find it on the [My Assets Page](#my-assets-page).
 
 ### Modify static content
 
@@ -107,7 +107,7 @@ Once everything has filled out, you should be able to click the â€œCreate Assetâ
 
 This page displays all the assets that have been created under the current Move module. You can click on the asset address, which redirects you to the Aptos Explorer site where you can see your asset.
 
-When you are ready to use an asset on the Public Mint Page, you need to copy the asset address and assign it to the `asset_id` on the `frontend/config.ts` file.
+When you are ready to use an asset on the Public Mint Page, you need to copy the asset address and assign it to the `fa_address` on the `frontend/config.ts` file.
 
 Some stats are available on this page, like the max supply of the asset and the number of asset minted.
 

--- a/apps/nextra/pages/en/build/create-aptos-dapp/templates/token-minting-dapp.mdx
+++ b/apps/nextra/pages/en/build/create-aptos-dapp/templates/token-minting-dapp.mdx
@@ -31,7 +31,7 @@ npm run dev
 
 ### Configure an asset address
 
-For the public mint page to fetch the asset, you will need to configure the asset address. First, assign the `asset_id` variable in the `frontend/config.ts` file with the asset address. If you have [created the asset](#create-a-fungible-asset-page) with the tool, you should be able to find it on the [My Assets Page](#my-assets-page).
+For the public mint page to fetch the asset, you will need to configure the asset address. First, assign the `fa_address` variable in the `frontend/config.ts` file with the asset address. If you have [created the asset](#create-a-fungible-asset-page) with the tool, you should be able to find it on the [My Assets Page](#my-assets-page).
 
 ### Modify static content
 
@@ -123,7 +123,7 @@ Once everything has filled out, you should be able to click the â€œCreate Assetâ
 
 This page displays all the assets that have been created under the current Move module. You can click on the asset address, which redirects you to the Aptos Explorer site where you can see your asset.
 
-When you are ready to use an asset on the Public Mint Page, you need to copy the asset address and assign it to the `asset_id` on the `frontend/config.ts` file.
+When you are ready to use an asset on the Public Mint Page, you need to copy the asset address and assign it to the `fa_address` on the `frontend/config.ts` file.
 
 Some stats are available on this page, like the max supply of the asset and the number of asset minted.
 


### PR DESCRIPTION
### Description
Change docs to say `fa_address` instead of `asset_id` for our token minting template in create-aptos-dapp.

Related PR: https://github.com/aptos-labs/create-aptos-dapp/pull/162#pullrequestreview-2208899812

Updated doc:
<img width="851" alt="image" src="https://github.com/user-attachments/assets/79d5751b-5a5b-4a16-8742-2c840ee18dfe">


### Checklist

- Do all Lints pass?
  - [ ] Have you ran `pnpm spellcheck`?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
