### PR TITLE
Tweak wording around wallet selector UI package docs

### DIFF
--- a/apps/nextra/pages/en/build/sdks/wallet-adapter/dapp.mdx
+++ b/apps/nextra/pages/en/build/sdks/wallet-adapter/dapp.mdx
@@ -121,7 +121,7 @@ For UI components that work out of the box, but are less customizable, choose on
 - [Ant Design](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/packages/wallet-adapter-ant-design)
 - [MUI](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/packages/wallet-adapter-mui-design) (Material UI)
 
-Otherwise, you should use the [shadcn/ui](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/packages/wallet-adapter-react/src/components/WalletItem.tsx) package, as it has the most customization options. For more details on how to customize [shadcn/ui](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/packages/wallet-adapter-react/src/components/WalletItem.tsx), see [this guide](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/packages/wallet-adapter-react/docs/BYO-wallet-selector.md).
+Otherwise, you should use the [shadcn/ui wallet selector](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/apps/nextjs-example/README.md#use-shadcnui-wallet-selector-for-your-own-app), as it has the most customization options. For more details on how to customize this wallet selector or build your own wallet selector, see [this guide](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/packages/wallet-adapter-react/docs/BYO-wallet-selector.md).
 
 <Callout type="info">
 For an example that shows how these UI options work in practice, see the [live demo app](https://aptos-labs.github.io/aptos-wallet-adapter/) (you can find its reference code [here](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/apps/nextjs-example)).


### PR DESCRIPTION
### Description

This PR just adds a bit more clarity around the `shadcn/ui` wallet selector and BYO wallet selector guide.

The `shadcn/ui` wallet selector isn't actually a package, but rather code you can copy into your codebase and edit yourself so I removed the word "package" from its description.

Also I mentioned that the guide linked can be useful if you want to build your wallet selector instead of using one of the wallet selectors that we provide.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
