### PR TITLE
[move-book] Extending Book by Move 2.0 Documentation

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/book/SUMMARY.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/SUMMARY.mdx
@@ -5,6 +5,10 @@
 - [Modules and Scripts](modules-and-scripts.mdx)
 - [Move Tutorial](move-tutorial.mdx)
 
+## Language Release Notes
+
+- [Move 2.0](move-2.0.mdx)
+
 ## Primitive Types
 
 - [Integers](integers.mdx)
@@ -24,6 +28,7 @@
 - [While, For, and Loop](loops.mdx)
 - [Functions](functions.mdx)
 - [Structs and Resources](structs-and-resources.mdx)
+- [Enum Types](enums.mdx)
 - [Constants](constants.mdx)
 - [Generics](generics.mdx)
 - [Type Abilities](abilities.mdx)

--- a/apps/nextra/pages/en/build/smart-contracts/book/_meta.tsx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/_meta.tsx
@@ -1,115 +1,115 @@
 export default {
-    SUMMARY: {
-        title: "Summary",
-    },
-    "---getting-started---": {
-        type: "separator",
-        title: "Getting Started",
-    },
-    "modules-and-scripts": {
-        title: "Modules and Scripts",
-    },
-    "move-tutorial": {
-        title: "Move Tutorial",
-    },
-    "---primitive-types---": {
-        type: "separator",
-        title: "Primitive Types",
-    },
-    integers: {
-        title: "Integers",
-    },
-    bool: {
-        title: "Bool",
-    },
-    address: {
-        title: "Address",
-    },
-    vector: {
-        title: "Vector",
-    },
-    signer: {
-        title: "Signer",
-    },
-    references: {
-        title: "References",
-    },
-    tuples: {
-        title: "Tuples and Unit",
-    },
-    "---basic-concepts---": {
-        type: "separator",
-        title: "Basic Concepts",
-    },
-    variables: {
-        title: "Local Variables and Scopes",
-    },
-    equality: {
-        title: "Equality",
-    },
-    "abort-and-assert": {
-        title: "Abort and Assert",
-    },
-    conditionals: {
-        title: "Conditionals",
-    },
-    loops: {
-        title: "While, For, and Loop",
-    },
-    functions: {
-        title: "Functions",
-    },
-    "structs-and-resources": {
-        title: "Structs and Resources",
-    },
-    enums: {
-        title: "Enum Types",
-    },
-    constants: {
-        title: "Constants",
-    },
-    generics: {
-        title: "Generics",
-    },
-    abilities: {
-        title: "Type abilities",
-    },
-    uses: {
-        title: "Uses and Aliases",
-    },
-    friends: {
-        title: "Friends",
-    },
-    packages: {
-        title: "Packages",
-    },
-    "package-upgrades": {
-        title: "Package Upgrades",
-    },
-    "unit-testing": {
-        title: "Unit Tests",
-    },
-    "---global-storage---": {
-        type: "separator",
-        title: "Global Storage",
-    },
-    "global-storage-structure": {
-        title: "Global Storage Structure",
-    },
-    "global-storage-operators": {
-        title: "Global Storage Operators",
-    },
-    "---reference---": {
-        type: "separator",
-        title: "Reference",
-    },
-    "move-2.0": {
-        title: "Move 2.0 Release Notes",
-    },
-    "standard-library": {
-        title: "Standard Library",
-    },
-    "coding-conventions": {
-        title: "Coding Conventions",
-    },
+  SUMMARY: {
+    title: "Summary",
+  },
+  "move-2.0": {
+    title: "Move 2.0 Release Notes",
+  },
+  "---getting-started---": {
+    type: "separator",
+    title: "Getting Started",
+  },
+  "modules-and-scripts": {
+    title: "Modules and Scripts",
+  },
+  "move-tutorial": {
+    title: "Move Tutorial",
+  },
+  "---primitive-types---": {
+    type: "separator",
+    title: "Primitive Types",
+  },
+  integers: {
+    title: "Integers",
+  },
+  bool: {
+    title: "Bool",
+  },
+  address: {
+    title: "Address",
+  },
+  vector: {
+    title: "Vector",
+  },
+  signer: {
+    title: "Signer",
+  },
+  references: {
+    title: "References",
+  },
+  tuples: {
+    title: "Tuples and Unit",
+  },
+  "---basic-concepts---": {
+    type: "separator",
+    title: "Basic Concepts",
+  },
+  variables: {
+    title: "Local Variables and Scopes",
+  },
+  equality: {
+    title: "Equality",
+  },
+  "abort-and-assert": {
+    title: "Abort and Assert",
+  },
+  conditionals: {
+    title: "Conditionals",
+  },
+  loops: {
+    title: "While, For, and Loop",
+  },
+  functions: {
+    title: "Functions",
+  },
+  "structs-and-resources": {
+    title: "Structs and Resources",
+  },
+  enums: {
+    title: "Enum Types",
+  },
+  constants: {
+    title: "Constants",
+  },
+  generics: {
+    title: "Generics",
+  },
+  abilities: {
+    title: "Type abilities",
+  },
+  uses: {
+    title: "Uses and Aliases",
+  },
+  friends: {
+    title: "Friends",
+  },
+  packages: {
+    title: "Packages",
+  },
+  "package-upgrades": {
+    title: "Package Upgrades",
+  },
+  "unit-testing": {
+    title: "Unit Tests",
+  },
+  "---global-storage---": {
+    type: "separator",
+    title: "Global Storage",
+  },
+  "global-storage-structure": {
+    title: "Global Storage Structure",
+  },
+  "global-storage-operators": {
+    title: "Global Storage Operators",
+  },
+  "---reference---": {
+    type: "separator",
+    title: "Reference",
+  },
+  "standard-library": {
+    title: "Standard Library",
+  },
+  "coding-conventions": {
+    title: "Coding Conventions",
+  },
 };

--- a/apps/nextra/pages/en/build/smart-contracts/book/_meta.tsx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/_meta.tsx
@@ -1,109 +1,115 @@
 export default {
-  SUMMARY: {
-    title: "Summary",
-  },
-  "---getting-started---": {
-    type: "separator",
-    title: "Getting Started",
-  },
-  "modules-and-scripts": {
-    title: "Modules and Scripts",
-  },
-  "move-tutorial": {
-    title: "Move Tutorial",
-  },
-  "---primitive-types---": {
-    type: "separator",
-    title: "Primitive Types",
-  },
-  integers: {
-    title: "Integers",
-  },
-  bool: {
-    title: "Bool",
-  },
-  address: {
-    title: "Address",
-  },
-  vector: {
-    title: "Vector",
-  },
-  signer: {
-    title: "Signer",
-  },
-  references: {
-    title: "References",
-  },
-  tuples: {
-    title: "Tuples and Unit",
-  },
-  "---basic-concepts---": {
-    type: "separator",
-    title: "Basic Concepts",
-  },
-  variables: {
-    title: "Local Variables and Scopes",
-  },
-  equality: {
-    title: "Equality",
-  },
-  "abort-and-assert": {
-    title: "Abort and Assert",
-  },
-  conditionals: {
-    title: "Conditionals",
-  },
-  loops: {
-    title: "While, For, and Loop",
-  },
-  functions: {
-    title: "Functions",
-  },
-  "structs-and-resources": {
-    title: "Structs and Resources",
-  },
-  constants: {
-    title: "Constants",
-  },
-  generics: {
-    title: "Generics",
-  },
-  abilities: {
-    title: "Type abilities",
-  },
-  uses: {
-    title: "Uses and Aliases",
-  },
-  friends: {
-    title: "Friends",
-  },
-  packages: {
-    title: "Packages",
-  },
-  "package-upgrades": {
-    title: "Package Upgrades",
-  },
-  "unit-testing": {
-    title: "Unit Tests",
-  },
-  "---global-storage---": {
-    type: "separator",
-    title: "Global Storage",
-  },
-  "global-storage-structure": {
-    title: "Global Storage Structure",
-  },
-  "global-storage-operators": {
-    title: "Global Storage Operators",
-  },
-  "---reference---": {
-    type: "separator",
-    title: "Reference",
-  },
-  "standard-library": {
-    title: "Standard Library",
-  },
-  "coding-conventions": {
-    title: "Coding Conventions",
-  },
+    SUMMARY: {
+        title: "Summary",
+    },
+    "---getting-started---": {
+        type: "separator",
+        title: "Getting Started",
+    },
+    "modules-and-scripts": {
+        title: "Modules and Scripts",
+    },
+    "move-tutorial": {
+        title: "Move Tutorial",
+    },
+    "---primitive-types---": {
+        type: "separator",
+        title: "Primitive Types",
+    },
+    integers: {
+        title: "Integers",
+    },
+    bool: {
+        title: "Bool",
+    },
+    address: {
+        title: "Address",
+    },
+    vector: {
+        title: "Vector",
+    },
+    signer: {
+        title: "Signer",
+    },
+    references: {
+        title: "References",
+    },
+    tuples: {
+        title: "Tuples and Unit",
+    },
+    "---basic-concepts---": {
+        type: "separator",
+        title: "Basic Concepts",
+    },
+    variables: {
+        title: "Local Variables and Scopes",
+    },
+    equality: {
+        title: "Equality",
+    },
+    "abort-and-assert": {
+        title: "Abort and Assert",
+    },
+    conditionals: {
+        title: "Conditionals",
+    },
+    loops: {
+        title: "While, For, and Loop",
+    },
+    functions: {
+        title: "Functions",
+    },
+    "structs-and-resources": {
+        title: "Structs and Resources",
+    },
+    "enums": {
+        title: "Enum Types",
+    },
+    constants: {
+        title: "Constants",
+    },
+    generics: {
+        title: "Generics",
+    },
+    abilities: {
+        title: "Type abilities",
+    },
+    uses: {
+        title: "Uses and Aliases",
+    },
+    friends: {
+        title: "Friends",
+    },
+    packages: {
+        title: "Packages",
+    },
+    "package-upgrades": {
+        title: "Package Upgrades",
+    },
+    "unit-testing": {
+        title: "Unit Tests",
+    },
+    "---global-storage---": {
+        type: "separator",
+        title: "Global Storage",
+    },
+    "global-storage-structure": {
+        title: "Global Storage Structure",
+    },
+    "global-storage-operators": {
+        title: "Global Storage Operators",
+    },
+    "---reference---": {
+        type: "separator",
+        title: "Reference",
+    },
+    "move-2.0": {
+        title: "Move 2.0 Release Notes",
+    },
+    "standard-library": {
+        title: "Standard Library",
+    },
+    "coding-conventions": {
+        title: "Coding Conventions",
+    },
 };

--- a/apps/nextra/pages/en/build/smart-contracts/book/_meta.tsx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/_meta.tsx
@@ -62,7 +62,7 @@ export default {
     "structs-and-resources": {
         title: "Structs and Resources",
     },
-    "enums": {
+    enums: {
         title: "Enum Types",
     },
     constants: {

--- a/apps/nextra/pages/en/build/smart-contracts/book/abort-and-assert.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/abort-and-assert.mdx
@@ -76,7 +76,8 @@ if (condition) () else abort code
 ```
 
 Since Move 2.0, `assert` without an error code is supported. If this assert is used, the
-abort code `0xD8CA26CBD9BE00000000` is generated. 
+abort code `0xCA26CBD9BE0B0000` is generated.  In terms of the `std::error` convention, this code has
+category `std::error::INTERNAL` and reason `0`.
 
 `assert` is more commonly used than just `abort` by itself. The `abort` examples above can be
 rewritten using `assert`

--- a/apps/nextra/pages/en/build/smart-contracts/book/abort-and-assert.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/abort-and-assert.mdx
@@ -64,6 +64,7 @@ condition of type `bool` and a code of type `u64`
 
 ```move
 assert!(condition: bool, code: u64)
+assert!(condition: bool) // Since Move 2.0
 ```
 
 Since the operation is a macro, it must be invoked with the `!`. This is to convey that the
@@ -73,6 +74,9 @@ does not exist at the bytecode level. It is replaced inside the compiler with
 ```move
 if (condition) () else abort code
 ```
+
+Since Move 2.0, `assert` without an error code is supported. If this assert is used, the
+abort code `0xD8CA26CBD9BE00000000` is generated. 
 
 `assert` is more commonly used than just `abort` by itself. The `abort` examples above can be
 rewritten using `assert`

--- a/apps/nextra/pages/en/build/smart-contracts/book/enums.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/enums.mdx
@@ -95,8 +95,8 @@ Notice above that the value matched is an immutable reference to an enum value. 
 ```move
 fun scale_radius(self: &mut Rectangle, factor:  u64) {
     match (self) {
-        Circle{radius} => *radius = *radius * factor,
-        _              => {} // do nothing if not a Circle
+        Circle{radius: r} => *r = *r * factor,
+        _                 => {} // do nothing if not a Circle
   }
 }
 ```
@@ -106,19 +106,17 @@ The patterns provided in the match expression are evaluated sequentially, in ord
 Patterns can be nested and contain conditions, as in the following example:
 
 ```move
-use Result::*;
 let r : Result<Result<u64>> = Ok(Err(42));
 let v = match (r)) {
   Ok(Err(c)) if c < 42  => 0,
   Ok(Err(c)) if c >= 42 => 1,
   Ok(_)                 => 2,
-  _                     => 3 
+  _                     => 3
+};
 assert!(v == 1);
 ```
 
-Notice that in the above example, the last match clause (`_`) covers both patterns `Ok(Err(_))` and `Err(_)`.  Although at execution time, the earlier clauses may match `Ok(Err(c))` for all values of `c`, the compiler cannot be sure all cases are covered due to the conditionals: conditions in match expressions are not considered when tracking coverage.  Thus the first two clauses in the match expression above are not sufficient for match completeness, and an additional clause is required to avoid a compiler error.
-
-Notice that while match completeness is enforced by the compiler, at  runtime it may not be guaranteed if code is upgraded. See the discussion of upgrade compatibility of enums here.
+Notice that in the above example, the last match clause (`_`) covers both patterns `Ok(Err(_))` and `Err(_)`.  Although at execution time, the earlier clauses match `Ok(Err(c))` for all values of `c`, the compiler cannot be sure all cases are covered due to the conditionals: conditions in match expressions are not considered when tracking coverage.  Thus the first two clauses in the match expression above are not sufficient for match completeness, and an additional clause is required to avoid a compiler error.
 
 ## Testing Enum Variants
 
@@ -134,7 +132,6 @@ The operator allows specifying a list of variants, separated by "`|`" characters
 ```move
 assert!(data is V1|V2);
 ```
-
 
 ## Selecting From Enum Values
 
@@ -153,19 +150,20 @@ One can write code as below to directly select the fields of variants:
 let s: String;
 let data1 = VersionedData::V1{name: s};
 let data2 = VersionedData::V2{name: s, age: 20};
-assert!(data1 is VersionData::V2);
 assert!(data1.name == data2.name)
-assert!(data2.age == 20); // Note that `data1.age` will abort!
+assert!(data2.age == 20); 
 ```
 
 Notice that field selection aborts if the enum value has no variant with the given field. This is the case for  `data1.age`. 
+The abort code used for this case is `0xCA26CBD9BE0B0001`. In terms of the `std::error` convention, this code has
+category `std::error::INTERNAL` and reason `1`.
 
 Field selection is only possible if the field is uniquely named and typed throughout all variants. Thus, the following yields a compile time error:
 
 ```move
 enum VersionedData has key {
   V1{name: String}
-  V3{name: u64}
+  V2{name: u64}
 }
 
 data.name

--- a/apps/nextra/pages/en/build/smart-contracts/book/enums.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/enums.mdx
@@ -1,0 +1,214 @@
+# Enums
+
+_Since language version 2.0_
+
+Enum types are similar to struct types but support defining multiple *variants* of the data layout. Each variant has its distinct set of fields. Enum variants are supported in expressions, tools for testing, matching, and deconstructing. 
+
+
+## Declaration of Enum Types 
+
+An enum type declaration lists the number of different variants, as seen in the example below:
+
+```move
+enum Shape {
+    Circle{radius: u64},
+    Rectangle{width: u64, height: u64}
+}
+```
+
+There can be zero or more fields for an enum variant. If no arguments are given, the braces can also be omitted, declaring simple values:
+
+```move
+enum Color {
+  Red, Blue, Green
+}
+```
+
+Like struct types, enum types can have abilities. For example, the `Color` enum type would be appropriately declared as copyable, droppable, and storable, like primitive number types:
+
+```move
+enum Color has copy, drop, store, key { Red, Blue, Green }
+```
+
+Enum types can also have the `key` ability and appear as roots of data in global storage. A common usage of enums in this context is versioning of data:
+
+```move
+enum VersionedData has key {
+  V1{name: String}
+  V2{name: String, age: u64}
+}
+```
+
+Similar to structs, enum types can be generic and take positional arguments. For example, the type below represents a generic result type, where the variant constructors use positional instead of named arguments (see also [positional structs](structs-and-resources.mdx#positional-structs)).
+
+```move
+enum Result<T> has copy, drop, store {
+  Err(u64),
+  Ok(T)
+}
+```
+
+## Constructing Enum Values 
+
+An enum value is constructed similarly to a struct value:
+
+```move
+let s: String;
+let data = VersionedData::V1{name: s};
+```
+
+If the enum variant has no fields, the braces can also be omitted:
+
+```move
+let color = Color::Blue;
+```
+
+## Name Resolution for Enum Variants 
+
+The variant names for an enum need to be qualified by the enum type name, as in `VersionedData::V1`. 
+
+> Note:" Aliasing via the `use` clause is currently not supported for enum variants, but will be added in later language versions
+
+In certain cases (such as match expressions, below), the Move compiler can infer the enum type from the context, and the qualification by the type name may be omitted:
+
+```move
+fun f(data: VersionedData) {
+  match (data) { V1{..} => .., ..} // simple variant name OK
+}
+```
+
+## Matching Enum Values 
+
+The value of an enum value can be inspected using a match expression. For example:
+
+```move
+fun area(self: &Rectangle): u64 {
+    match (self) {
+        Circle{radius}           => mul_with_pi(*radius * *radius),
+        Rectangle{width, height) => *width * *height
+    }
+}
+```
+
+Notice above that the value matched is an immutable reference to an enum value. A match expression can also consume a value, or match over a mutable reference for interior updates:
+
+```move
+fun scale_radius(self: &mut Rectangle, factor:  u64) {
+    match (self) {
+        Circle{radius} => *radius = *radius * factor,
+        _              => {} // do nothing if not a Circle
+  }
+}
+```
+
+The patterns provided in the match expression are evaluated sequentially, in order of textual occurrence, until a match is found. It is a compile time error if not all known patterns are covered.
+
+Patterns can be nested and contain conditions, as in the following example:
+
+```move
+use Result::*;
+let r : Result<Result<u64>> = Ok(Err(42));
+let v = match (r)) {
+  Ok(Err(c)) if c < 42  => 0,
+  Ok(Err(c)) if c >= 42 => 1,
+  Ok(_)                 => 2,
+  _                     => 3 
+assert!(v == 1);
+```
+
+Notice that in the above example, the last match clause (`_`) covers both patterns `Ok(Err(_))` and `Err(_)`.  Although at execution time, the earlier clauses may match `Ok(Err(c))` for all values of `c`, the compiler cannot be sure all cases are covered due to the conditionals: conditions in match expressions are not considered when tracking coverage.  Thus the first two clauses in the match expression above are not sufficient for match completeness, and an additional clause is required to avoid a compiler error.
+
+Notice that while match completeness is enforced by the compiler, at  runtime it may not be guaranteed if code is upgraded. See the discussion of upgrade compatibility of enums here.
+
+## Testing Enum Variants
+
+With the `is` operator, one can examine whether a given enum value is of a given variant:
+
+```move
+let data: VersionedData;
+if (data is VersionedData::V1) { .. }
+```
+
+The operator allows specifying a list of variants, separated by "`|`" characters. The variants need not be qualified by the enum name if the type of the expression being tested is known:
+
+```move
+assert!(data is V1|V2);
+```
+
+
+## Selecting From Enum Values
+
+It is possible to directly select a field from an enum value. Recall the definition of versioned data:
+
+```move
+enum VersionedData has key {
+  V1{name: String}
+  V2{name: String, age: u64}
+}
+```
+
+One can write code as below to directly select the fields of variants:
+
+```move
+let s: String;
+let data1 = VersionedData::V1{name: s};
+let data2 = VersionedData::V2{name: s, age: 20};
+assert!(data1 is VersionData::V2);
+assert!(data1.name == data2.name)
+assert!(data2.age == 20); // Note that `data1.age` will abort!
+```
+
+Notice that field selection aborts if the enum value has no variant with the given field. This is the case for  `data1.age`. 
+
+Field selection is only possible if the field is uniquely named and typed throughout all variants. Thus, the following yields a compile time error:
+
+```move
+enum VersionedData has key {
+  V1{name: String}
+  V3{name: u64}
+}
+
+data.name
+ // ^^^^^ compile time error that `name` field selection is ambigious
+```
+
+## Using Enums Patterns in Lets
+
+An enum variant pattern may be used in a `let` statement:
+
+```move
+let data: VersionData;
+let V1{name} = data;
+```
+
+Unpacking the enum value will abort if the variant is not the expected one. To ensure that all variants of an enum are handled, a `match` expression is recommended instead of a `let`. The `match` is checked at compile time, ensuring that all variants are covered. In some cases, tools like the Move Prover can be used to verify that unexpected aborts cannot happen with a `let`.
+
+
+## Enum Type Upgrade Compatibility 
+
+An enum type can be upgraded by another enum type if the new type only adds new variants at the end of the variant list. All variants present in the old enum type must also appear in the new type, in the same order and starting from the beginning. Consider the `VersionedData` type, which might have begun with a single version:
+
+
+```move
+enum VersionedData has key {
+  V1{name: String}
+}
+```
+
+This type could be upgraded to the version we used so far in this text:
+
+```move
+enum VersionedData has key {
+  V1{name: String}
+  V2{name: String, age: u64}
+}
+```
+
+That following upgrade would not be allowed, since the order of variants must be preserved:
+
+```move
+enum VersionedData has key {
+  V2{name: String, age: u64}   // not a compatible upgrade
+  V1{name: String}
+}
+```

--- a/apps/nextra/pages/en/build/smart-contracts/book/enums.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/enums.mdx
@@ -67,7 +67,7 @@ let color = Color::Blue;
 
 The variant names for an enum need to be qualified by the enum type name, as in `VersionedData::V1`. 
 
-> Note:" Aliasing via the `use` clause is currently not supported for enum variants, but will be added in later language versions
+> Note: Aliasing via the `use` clause is currently not supported for enum variants, but will be added in later language versions
 
 In certain cases (such as match expressions, below), the Move compiler can infer the enum type from the context, and the qualification by the type name may be omitted:
 

--- a/apps/nextra/pages/en/build/smart-contracts/book/functions.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/functions.mdx
@@ -88,7 +88,7 @@ A `package` function can be only called within the same package. The notion of a
 defined by the hosting environment of Move, and not explicit in the language. Typically, the package
 is defined by a manifest file `Move.toml` which is processed by the build environment. 
 
-The following works, provided the two modules belong to the same package:
+The following works, provided the two modules belong to the same package and are at the same address:
 
 ```move
 module 0x42::m {
@@ -104,7 +104,10 @@ module 0x42::other {
 
 An attempt to access `0x42::m::foo` from another package will fail at compile time.
 
-Notice that package visibility is a compile time concept which is reduced by the compiler to friend visibility (described [below](#friend-visibility)), which can be verified by the Move VM.
+In addition to the notation `package fun`, also the longer notation `public(package) fun` is supported.
+
+Notice that package visibility is a compile time concept which is reduced by the compiler to friend visibility (described [below](#friend-visibility)), which can be verified by the Move VM. The Move VM guarantees that friend functions
+cannot be called across address boundaries, independent of what package system a compilation environment supports.
 
 
 #### `public(friend)` visibility
@@ -114,9 +117,9 @@ _Since Language Version 2.0_, `friend fun` replaces `public(friend) fun`. The ol
 The `public(friend)` visibility modifier is a more restricted form of the `public` modifier to give more control about where a function can be used. A `public(friend)` function can be called by:
 
 - other functions defined in the same module, or
-- functions defined in modules which are explicitly specified in the **friend list** (see [Friends](friends.mdx) on how to specify the friend list).
+- functions defined in modules which are explicitly specified in the **friend list** (see [Friends](friends.mdx) on how to specify the friend list), and which reside at the same address.
 
-Note that since we cannot declare a script to be a friend of a module, the functions defined in scripts can never call a `public(friend)` function.
+Note that since we cannot declare a script to be a friend of a module, the functions defined in scripts can never call a `public(friend)` function. 
 
 ```move
 address 0x42 {

--- a/apps/nextra/pages/en/build/smart-contracts/book/functions.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/functions.mdx
@@ -80,7 +80,36 @@ script {
 }
 ```
 
+### `package` visibility
+
+_Since Language Version 2.0_
+
+A `package` function can be only called within the same package. The notion of a package is
+defined by the hosting environment of Move, and not explicit in the language. Typically, the package
+is defined by a manifest file `Move.toml` which is processed by the build environment. 
+
+The following works, provided the two modules belong to the same package:
+
+```move
+module 0x42::m {
+  package fun foo(): u64 { 0 }
+}
+
+module 0x42::other {
+  fun calls_m_foo(): u64 {
+    0x42::m::foo() // valid
+  }
+}
+```
+
+An attempt to access `0x42::m::foo` from another package will fail at compile time.
+
+Notice that package visibility is a compile time concept which is reduced by the compiler to friend visibility (described [below](#friend-visibility)), which can be verified by the Move VM.
+
+
 #### `public(friend)` visibility
+
+_Since Language Version 2.0_, `friend fun` replaces `public(friend) fun`. The old notation is still supported.
 
 The `public(friend)` visibility modifier is a more restricted form of the `public` modifier to give more control about where a function can be used. A `public(friend)` function can be called by:
 
@@ -94,6 +123,7 @@ address 0x42 {
 module m {
     friend 0x42::n;  // friend declaration
     public(friend) fun foo(): u64 { 0 }
+    friend fun foo2(): u64 { 0 } // Since Move 2.0
 
     fun calls_foo(): u64 { foo() } // valid
 }

--- a/apps/nextra/pages/en/build/smart-contracts/book/global-storage-operators.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/global-storage-operators.mdx
@@ -267,7 +267,7 @@ The table below gives an overview of index notations for storage:
 | `&T[address].field`     | `&borrow_global<T>(address).field`         |
 | `&mut T[address].field` | `&mut borrow_global_mut<T>(address).field` |
 | `T[address].field`      | `borrow_global<T>(address).field`          |
-| `T[address].field = x`  | `*borrow_global_mut<T>(address).field = x`  |
+| `T[address].field = x`  | `borrow_global_mut<T>(address).field = x`  |
 
 Here `T` represents a generic resource type that can take type parameters.
 

--- a/apps/nextra/pages/en/build/smart-contracts/book/global-storage-operators.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/global-storage-operators.mdx
@@ -12,6 +12,9 @@ Move programs can create, delete, and update [resources](structs-and-resources.m
 
 Each of these instructions is parameterized by a type `T` with the [`key` ability](abilities.mdx). However, each type `T` _must be declared in the current module_. This ensures that a resource can only be manipulated via the API exposed by its defining module. The instructions also take either an [`address`](address.mdx) or [`&signer`](signer.mdx) representing the account address where the resource of type `T` is stored.
 
+See also [index notation (`[]`)](#index-notation-for-storage-operators) for accessing global storage.
+
+
 ## References to resources
 
 References to global resources returned by `borrow_global` or `borrow_global_mut` mostly behave like references to local storage: they can be extended, read, and written using ordinary [reference operators](references.mdx) and passed as arguments to other function. However, there is one important difference between local and global references: **a function cannot return a reference that points into global storage**. For example, these two functions will each fail to compile:
@@ -30,7 +33,8 @@ module 0x42::example {
 }
 ```
 
-Move must enforce this restriction to guarantee absence of dangling references to global storage. [This section](#reference-safety-for-global-resources) contains much more detail for the interested reader.
+Move must enforce this restriction to guarantee absence of dangling references to global 
+storage. [This section](#reference-safety-for-global-resources) contains much more detail for the interested reader.
 
 ## Global storage operators with generics
 
@@ -243,3 +247,43 @@ address 0x42 {
 Line 16 acquires a reference to a global resource `m1::T`, then line 17 removes that same resource, which makes `t_ref` dangle. In this case, `acquires` annotations do not help us because the `borrow_then_remove_bad` function is outside the `m1` module that declares `T` (recall that `acquires` annotations can only be used for resources declared in the current module). Instead, the type system avoids this problem by preventing the return of a global reference at line 6.
 
 Fancier type systems that would allow returning global references without sacrificing reference safety are possible, and we may consider them in future iterations of Move. We chose the current design because it strikes a good balance between being expressive, annotation burden, and type system complexity.
+
+
+## Index Notation for Storage Operators
+
+_Since language version 2.0_
+
+Instead of the verbose `borrow_global` and `borrow_global_mut` functions, one
+can also use index notations to access global storage.
+
+The table below gives an overview of index notations for storage:
+
+| Indexing Syntax         | Storage Operation                          |
+|-------------------------|--------------------------------------------|
+| `&T[address]`           | `borrow_global<T>(address)`                |
+| `&mut T[address]`       | `borrow_global_mut<T>(address)`            |
+| `T[address]`            | `*borrow_global<T>(address)`               |
+| `T[address] = x`        | `*borrow_global_mut<T>(address) = x`       |
+| `&T[address].field`     | `&borrow_global<T>(address).field`         |
+| `&mut T[address].field` | `&mut borrow_global_mut<T>(address).field` |
+| `T[address].field`      | `borrow_global<T>(address).field`          |
+| `T[address].field = x`  | `*borrow_global_mut<T>(address).field = x`  |
+
+Here `T` represents a generic resource type that can take type parameters.
+
+Notice that `T[address].field` fetches a reference to the resource from storage and then makes a copy of the field value (which must
+have the copy ability); it is a shortcut for `*&T[address].field`.
+
+Examples:
+
+```move
+struct R has key, drop { value: bool }
+
+fun f1() acquires R {
+  let x = &mut R[@0x1];
+  x.value = false;
+  assert!(R[@0x1].value == false);
+  R[@0x1].value = true;
+  assert!(R[@0x1].value == true);
+}
+```

--- a/apps/nextra/pages/en/build/smart-contracts/book/integers.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/integers.mdx
@@ -152,6 +152,8 @@ For example:
 - `(1 + 3 as u128)`
 - `(4/2 + 12345 as u256)`
 
+Notice that since Language Version 2.0, casts don't always need to be in parentheses. Thus, `x as u8` is a valid expression.
+
 ## Ownership
 
 As with the other scalar values built-in to the language, integer values are implicitly copyable, meaning they can be copied without an explicit instruction such as [`copy`](variables.mdx#move-and-copy).

--- a/apps/nextra/pages/en/build/smart-contracts/book/move-2.0.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/move-2.0.mdx
@@ -1,0 +1,20 @@
+# Move 2.0 Language Release
+
+The Move 2.0 language release adds a number of new features to Move. The documentation of those features is integrated into the book, and marked in text with "_Since language version 2.0_". This section gives an overview of the new features and links to the documentation:
+
+
+- **Enum Types** add the option to define different variants of data layout in one storable type. They are documented in the [Enum Type section](enums.mdx).
+
+- **Receiver Style Functions** add the ability to call functions in the familiar notation `value.func(arg)`. They are documented in [this section](functions.mdx#dot-receiver-function-call-style).
+
+- **Index Notation** allows to access [elements of vectors](vector.mdx#index-notation-for-vectors) and of [resource storage](global-storage-operators.mdx#index-notation-for-storage-operators) with notations like `&mut vector[index]`, or `&mut Resource[addr]`, respectively. 
+
+- **Positional Structs** allow to define wrapper types such as `struct Wrapped(u64)`. Positional structs are described [here](structs-and-resources.mdx#positional-structs). Enum variants are also allowed to be positional.
+
+- **Dot-dot pattern wildcards** enable statements like `let Struct{x, ..} = value` to match selective parts of data. They are described [here](structs-and-resources.mdx#partial-patterns). Those patterns are also allowed for enum variants.
+
+- **Package visibility** allows to declare a function to be visible anywhere inside, but not outside a package. Friend functions continue to be supported, although package visibility is in many cases more suitable. As a more concise notation, package and friend functions can be simply declared as `package fun` or `friend fun`, respectively, instead of the longer `public(package) fun` and `public(friend) fun`. This feature is documented [here](functions.mdx#package-visibility).
+
+- **Assert abort code optional** The `assert!` macro can now be used with just one argument, omitting the abort code, in which case a default code will be chosen. See also [here](abort-and-assert.mdx#assert).
+ 
+- **New Cast Syntax** Until now, casts had to always be in parentheses, requiring code like `function((x as u256))`. This requirement is now dropped and casts can be top-level expressions without parenthesis, as in `function(x as u256)`. One still needs to write `(x as u64) + (y as u64)` in expressions. This similarly applies to the new enum variant test, `data is VersionedData::V1`.

--- a/apps/nextra/pages/en/build/smart-contracts/book/structs-and-resources.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/structs-and-resources.mdx
@@ -36,6 +36,8 @@ module 0x2::m {
   //              ^ error! Foo cannot contain Foo
 }
 ```
+For positional structs which used numbered instead of named fields, see 
+the [positional structs](#positional-structs) section.
 
 As mentioned above: by default, a struct declaration is linear and ephemeral. So to allow the value
 to be used with certain operations (that copy it, drop it, store it in global storage, or use it as
@@ -48,7 +50,8 @@ module 0x2::m {
 }
 ```
 
-For more details, see the [annotating structs](abilities.mdx#annotating-structs) section.
+For more details, see the [annotating structs](abilities.mdx#annotating-structs) section. 
+
 
 ### Naming
 
@@ -98,7 +101,7 @@ module 0x2::m {
 }
 ```
 
-This is called sometimes called "field name punning".
+This is sometimes called "field name punning".
 
 ### Destroying Structs via Pattern Matching
 
@@ -421,9 +424,95 @@ module 0x2::m {
 }
 ```
 
+## Positional Structs
+
+_Since language version 2.0_
+
+A struct can be declared to have _positional fields_, fields which are not named
+but numbered. Positional structs behave similar to regular structs,
+except providing a different syntax which may be more suitable for use cases with 
+only a few fields.
+
+Fields of positional structs are assigned in the order they appear. In the below
+example, field `0` is of type `u64` and field `1` of type `u8`:
+
+```move
+module 0x2::m {
+  struct Pair(u64, u8);
+}
+```
+
+Abilities for positional structs are declared _after_ and not before the field list,
+
+```move
+module 0x2::m {
+  struct Pair(u64, u8) has copy, drop;
+}
+```
+
+For pure type tags, often used for phantom types in Move code, the list of arguments
+can be also completely omitted:
+
+```move
+module 0x2::m {
+  struct TypeTag has copy, drop;
+}
+```
+
+Values of positional structs are created and deconstructed as shown below:
+using `PositionalStructs(arguments)`:
+
+```move
+module 0x2::m {
+  fun work() {
+    let value = Pair(1, true);
+    let Pair(number, boolean) = value;
+    assert!(number == 1 && boolean == true);
+  }
+}
+```
+
+Fields of positional structs can be accessed using the position as a field selector. For example, in the above code example, `value.0` and `value.1` can be used to access the two fields without deconstructing the `value`.
+`positional_struct.0`.
+
+## Partial Patterns
+
+_Since language version 2.0_
+
+Patterns can use the `..` notation to match any remaining, non-listed fields in structs or variants with named fields, and omitted fields at either the beginning or end of a struct or variant with positional fields. Here are 
+some examples:
+
+```move
+module 0x2::m {
+  struct Foo{ x: u8, y: u16, z: u32 }
+  struct Bar(u8, u16, u32);
+  
+  fun foo_get_x(self: &Foo): u8 { 
+    let Foo{x, ..} = self;
+    x
+  }
+  
+  fun bar_get_0(self: &Foo): u8 { 
+    let Bar(x, ..) = self;
+    x
+  }
+  
+  fun bar_get_2(self: &Foo): u52 { 
+    // For positional structs, one can also put the 
+    // .. at the beginning.
+    let Bar(.., z) = self;
+    z
+  }
+}
+```
+
+Notice that partial patterns can currently not be used as the left-hand side of assignment.
+While one can use `let Bar(x, ..) = v`, we do not yet support `let x; Bar(x, ..) = v`. 
+
+
 ## Storing Resources in Global Storage
 
-Only structs with the `key` ability can be saved directly in
+Structs with the `key` ability can be saved directly in
 [persistent global storage](global-storage-operators.mdx). All values stored within those `key`
 structs must have the `store` ability. See the [ability](abilities.mdx) and
 [global storage](global-storage-operators.mdx) chapters for more detail.

--- a/apps/nextra/pages/en/build/smart-contracts/book/structs-and-resources.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/structs-and-resources.mdx
@@ -487,8 +487,8 @@ module 0x2::m {
   struct Foo{ x: u8, y: u16, z: u32 }
   struct Bar(u8, u16, u32);
   
-  fun foo_get_x(self: &Foo): u8 { 
-    let Foo{x, ..} = self;
+  fun foo_get_x(self: &Foo): u16 { 
+    let Foo{y, ..} = self;
     x
   }
   

--- a/apps/nextra/pages/en/build/smart-contracts/book/vector.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/vector.mdx
@@ -157,11 +157,11 @@ The table below gives an overview of index notations for vectors:
 | `&v[i]`           | `vector::borrow(&v, i)`                    |
 | `&mut v[i]`       | `vector::borrow_mut(&mut v, i)`            |
 | `v[i]`            | `*vector::borrow(&v, i)`                   |
-| `v[i] = x`        | `*vector::borrow(&v, i) = x`               |
+| `v[i] = x`        | `*vector::borrow_mut(&mut v, i) = x`       |
 | `&v[i].field`     | `&vector::borrow(&v, i).field`             |
 | `&mut v[i].field` | `&mut vector::borrow_mut(&mut v, i).field` |
-| `v[i].field`      | `vector::borrow(&v, i).field`               |
-| `v[i].field = x`  | `vector::borrow_mut(&mut v, i).field = x`       |
+| `v[i].field`      | `vector::borrow(&v, i).field`              |
+| `v[i].field = x`  | `vector::borrow_mut(&mut v, i).field = x`  |
 
 As an example, here is a bubble sort algorithm for vectors using index notation:
 

--- a/apps/nextra/pages/en/build/smart-contracts/book/vector.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/vector.mdx
@@ -122,7 +122,7 @@ Up-to-date document on `vector` can be found [here](https://github.com/aptos-lab
 | `vector::rotate<T>(v: &mut vector<T>, rot: u64): u64`                              | `rotate(&mut [1, 2, 3, 4, 5], 2) -> [3, 4, 5, 1, 2]` in place, returns the split point ie. 3 in this example                                                    | Never                                      |
 | `vector::rotate_slice<T>(v: &mut vector<T>, left: u64, rot: u64, right: u64): u64` | rotate a slice `[left, right)` with `left <= rot <= right` in place, returns the split point                                                                    | Never                                      |
 
-## Example
+Example:
 
 ```move
 script {
@@ -138,6 +138,51 @@ script {
     assert!(vector::pop_back(&mut v) == 6, 42);
     assert!(vector::pop_back(&mut v) == 5, 42);
   }
+}
+```
+
+## Index Notation for Vectors
+
+_Since language version 2.0_
+
+Index notation using square brackets (`[]`) is available for vector operations, simplifying syntax
+and making programs easier to understand. The index notation is simply syntactic sugar which
+is reduced to existing operations by the compiler;  the named operations are also still supported.
+
+The table below gives an overview of index notations for vectors:
+
+
+| Indexing Syntax   | Vector Operation                           |
+|-------------------|--------------------------------------------|
+| `&v[i]`           | `vector::borrow(&v, i)`                    |
+| `&mut v[i]`       | `vector::borrow_mut(&mut v, i)`            |
+| `v[i]`            | `*vector::borrow(&v, i)`                   |
+| `v[i] = x`        | `*vector::borrow(&v, i) = x`               |
+| `&v[i].field`     | `&vector::borrow(&v, i).field`             |
+| `&mut v[i].field` | `&mut vector::borrow_mut(&mut v, i).field` |
+| `v[i].field`      | `vector::borrow(&v, i).field`               |
+| `v[i].field = x`  | `vector::borrow_mut(&mut v, i).field = x`       |
+
+As an example, here is a bubble sort algorithm for vectors using index notation:
+
+```move
+fun bubble_sort(v: vector<u64>) {
+  use std::vector;
+  let n = vector::length(&v);
+  let i = 0;
+
+  while (i < n) {
+    let j = 0;
+    while (j < n - i - 1) {
+      if (v[j] > v[j + 1]) {
+        let t = v[j];
+        v[j] = v[j + 1];
+        v[j + 1] = t;
+      };
+      j = j + 1;
+    };
+    i = i + 1;
+  };
 }
 ```
 

--- a/apps/nextra/pages/en/build/smart-contracts/compiler_v2.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/compiler_v2.mdx
@@ -2,20 +2,19 @@
 title: "Move On Aptos Compiler (beta)"
 ---
 
-# Move On Aptos Compiler (beta)
+# Move On Aptos Compiler
 
 The Move on Aptos compiler (codename 'compiler v2') is a new tool which translates Move source code into Move bytecode. It unifies the architectures of the Move compiler and the Move Prover, enabling faster innovation in the Move language. It also offers new tools for defining code optimizations which can be leveraged to generate more gas efficient code for Move programs.
 
+The new compiler supports Move 2, the latest revision of the Move language. Head over to the [release page in the book](book/move-2.0.mdx) to learn more about the new features in Move 2. You can select both this language version and the new compiler by using `aptos move compile --move-2`.
 
-## Beta Testing
+## Compiler v2 Release State
 
-Compiler v2 (version `2.0-unstable`) is currently in beta testing and the developer community is encouraged to try it. However, the code produced by this version of the compiler can **NOT** be deployed on `mainnet`. Using it for unit tests or for local nodes, `devnet`, and `testnet` is fine. This page will be updated once this changes.
-
-Note that compiler v2 is not yet applying many code optimizations. As a result, the generated code is slightly less gas efficient than compiler v1. We expect this to change once the new compiler reaches production readiness.
+Compiler v2 is ready for production but not yet the default. You opt in to use compiler v2 and language Move 2 by using the `--move-2` flag passed to the Aptos CLI.
 
 ## Bug Bounty
 
-We award a bounty for each unique semantic bug identified in the compiler. Bugs need to surface as a difference of execution outcome of the v1 and v2 compilers, as demonstrated by a Move unit test. Try your existing Move tests with the new compiler, it is as easy as calling `aptos move test --compiler-version=2`! Not all differences in the compiler behavior count for the program, [head over here](https://hackenproof.com/audit-programs/aptos-labs/move-on-aptos-beta-compiler) for details of the bounty program. Even if a difference in behavior does not qualify for a bounty, we encourage you to open an issue using the link below.
+We award a bounty for each unique semantic bug identified in the compiler. Bugs need to surface as a difference of execution outcome of the v1 and v2 compilers, as demonstrated by a Move unit test. Try your existing Move tests with the new compiler, it is as easy as calling `aptos move test --compiler-version=2 --language-version=1`! Not all differences in the compiler behavior count for the program, [head over here](https://hackenproof.com/audit-programs/aptos-labs/move-on-aptos-beta-compiler) for details of the bounty program. Even if a difference in behavior does not qualify for a bounty, we encourage you to open an issue using the link below.
 
 ## Reporting an Issue
 
@@ -32,22 +31,10 @@ aptos update aptos # on supported OS
 brew upgrade aptos # on MacOS
 ```
 
-To run compiler v2, pass the flag `--compiler-version=2` to the Aptos CLI. Examples:
+To run compiler v2 and Move 2, pass the flag `--move-2` to the Aptos CLI. Examples:
 
 ```bash filename="Terminal"
-aptos move compile --compiler-version=2
-aptos move test --compiler-version=2
-aptos move prove --compiler-version=2
-```
-
-## Using Move 2
-
-Compiler v2 implements some first features of *Move 2*, the new edition of Move on Aptos. The scope of Move 2 is described in the blog [The Future of Move at Aptos](https://medium.com/aptoslabs/the-future-of-move-at-aptos-17d0656dcc31). The growing list of new features is documented below and will be extended as new features are added:
-
-- Receiver style function calls (see the [Move Book](book/functions.mdx) for more details)
-
-One must currently explicitly opt-in to use Move 2 with the flag `--language-version=2`:
-
-```bash filename="Terminal"
-aptos move compile --compiler-version=2 --language-version=2
+aptos move compile --move-2
+aptos move test --move-2
+aptos move prove --move-2
 ```


### PR DESCRIPTION
### Description

Adds documentation derived from our internal preparation documents. Also adds an overview page for Move 2 which links to other sections in the book.

One way to view this is via the latest vercel preview deployment which can be seen in the PR activity.

### Checklist

[All CI tests passed]

- Do all Lints pass?
  - [ ] Have you ran `pnpm spellcheck`?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
