### PR TITLE
Add "Start from template" step under CLI -> Get Started

### DIFF
--- a/apps/nextra/pages/en/build/cli/_meta.tsx
+++ b/apps/nextra/pages/en/build/cli/_meta.tsx
@@ -9,6 +9,9 @@ export default {
   "setup-cli": {
     title: "Setup",
   },
+  "start-from-template": {
+    title: "Start from template",
+  },
   "---usage---": {
     type: "separator",
     title: "Usage",

--- a/apps/nextra/pages/en/build/cli/start-from-template.mdx
+++ b/apps/nextra/pages/en/build/cli/start-from-template.mdx
@@ -1,0 +1,44 @@
+import { Card, Cards, RemoteCodeblock, permalinkFetch } from '@components/index';
+import { Steps } from "nextra/components"
+
+export async function getStaticProps() {
+  return await permalinkFetch([
+    "https://github.com/aptos-labs/aptos-core/blob/77e1d222ebc5e7294e115e0d090c001da1d0e072/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move#L1-L59"
+  ])
+}
+
+# Setup from a template
+You can set up a basic Move package from a template.
+
+<Steps>
+  ### Initialize
+  Run the following to get started with a pre-populated package:
+  ```bash filename="Terminal"
+  aptos move init --name hello_blockchain --template hello-blockchain
+  ```
+
+  ### Start building
+  The template creates a `hello_blockchain.move` file under `sources` to help get you started.
+  <RemoteCodeblock
+    permalink="https://github.com/aptos-labs/aptos-core/blob/77e1d222ebc5e7294e115e0d090c001da1d0e072/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move#L1-L59"
+  />
+
+  ### See all templates
+  Run the following command to see all templates (and for general help initializing a package):
+  ```bash
+  aptos move init --help
+  ```
+
+  ### Learn More
+  <Cards>
+    <Card href="../smart-contracts">
+      <Card.Title>Smart Contracts</Card.Title>
+      <Card.Description>Learn how to build in Move</Card.Description>
+    </Card>
+    <Card href="../smart-contracts/create-package">
+      <Card.Title>Create Package</Card.Title>
+      <Card.Description>Get started by learning how to create a Move package</Card.Description>
+    </Card>
+  </Cards>
+
+</Steps>

--- a/apps/nextra/pages/en/build/cli/start-from-template.mdx
+++ b/apps/nextra/pages/en/build/cli/start-from-template.mdx
@@ -7,12 +7,12 @@ export async function getStaticProps() {
   ])
 }
 
-# Setup from a template
-You can set up a basic Move package from a template.
+# Start a Move package from a template
+Follow the below steps to quickly get started.
 
 <Steps>
   ### Initialize
-  Run the following to get started with a pre-populated package:
+  Run the following to initialize a pre-populated package using the `hello-blockchain` template:
   ```bash filename="Terminal"
   aptos move init --name hello_blockchain --template hello-blockchain
   ```

--- a/apps/nextra/pages/en/build/cli/start-from-template.mdx
+++ b/apps/nextra/pages/en/build/cli/start-from-template.mdx
@@ -1,18 +1,18 @@
-import { Card, Cards, RemoteCodeblock, permalinkFetch } from '@components/index';
+import { Card, RemoteCodeblock, permalinkFetch } from '@components/index';
 import { Steps } from "nextra/components"
 
 export async function getStaticProps() {
   return await permalinkFetch([
-    "https://github.com/aptos-labs/aptos-core/blob/77e1d222ebc5e7294e115e0d090c001da1d0e072/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move#L1-L59"
+    "https://github.com/aptos-labs/aptos-core/blob/afd3706c17bcccfb39a9d6059aecbfa648ed295d/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move#L1-L64"
   ])
 }
 
 # Start a Move package from a template
-Follow the below steps to quickly get started.
+Follow the steps below to quickly get started.
 
 <Steps>
   ### Initialize
-  Run the following to initialize a pre-populated package using the `hello-blockchain` template:
+  Run the following to initialize a package using the `hello-blockchain` template:
   ```bash filename="Terminal"
   aptos move init --name hello_blockchain --template hello-blockchain
   ```
@@ -20,7 +20,7 @@ Follow the below steps to quickly get started.
   ### Start building
   The template creates a `hello_blockchain.move` file under `sources` to help get you started.
   <RemoteCodeblock
-    permalink="https://github.com/aptos-labs/aptos-core/blob/77e1d222ebc5e7294e115e0d090c001da1d0e072/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move#L1-L59"
+    permalink="https://github.com/aptos-labs/aptos-core/blob/afd3706c17bcccfb39a9d6059aecbfa648ed295d/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move#L1-L64"
   />
 
   ### See all templates
@@ -30,15 +30,13 @@ Follow the below steps to quickly get started.
   ```
 
   ### Learn More
-  <Cards>
-    <Card href="../smart-contracts">
-      <Card.Title>Smart Contracts</Card.Title>
-      <Card.Description>Learn how to build in Move</Card.Description>
-    </Card>
-    <Card href="../smart-contracts/create-package">
-      <Card.Title>Create Package</Card.Title>
-      <Card.Description>Get started by learning how to create a Move package</Card.Description>
-    </Card>
-  </Cards>
+  <Card href="../smart-contracts">
+    <Card.Title>Smart Contracts</Card.Title>
+    <Card.Description>Learn how to build in Move</Card.Description>
+  </Card>
+  <Card href="../smart-contracts/create-package">
+    <Card.Title>Create Package</Card.Title>
+    <Card.Description>Get started by learning how to create a Move package</Card.Description>
+  </Card>
 
 </Steps>

--- a/apps/nextra/pages/en/build/smart-contracts/create-package.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/create-package.mdx
@@ -7,14 +7,14 @@ import { RemoteCodeblock, permalinkFetch } from '@components/index';
 
 export async function getStaticProps() {
   return await permalinkFetch([
-    'https://github.com/aptos-labs/aptos-core/blob/77e1d222ebc5e7294e115e0d090c001da1d0e072/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move#L1-L59'
+    'https://github.com/aptos-labs/aptos-core/blob/afd3706c17bcccfb39a9d6059aecbfa648ed295d/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move#L1-L64'
   ])
 }
 
 # Create Package
 
 <Callout>
-We recommend installing the Aptos CLI before beginning. 
+We recommend installing the Aptos CLI before beginning.
 If you haven't already installed the Aptos CLI, see the [CLI section](../cli)
 </Callout>
 
@@ -36,6 +36,10 @@ You should now have a Move project that looks like so:
   <FileTree.Folder name="tests" defaultOpen></FileTree.Folder>
   <FileTree.File name="Move.toml" />
 </FileTree>
+
+<Callout type={"default"}>
+  You can also create a Move package from a [template](../cli/start-from-template).
+</Callout>
 
 ### Update `Move.toml`
 
@@ -66,8 +70,8 @@ subdir = "aptos-move/framework/aptos-framework"
 
 Add your code in the `sources` directory. Here we have a `hello_blockchain.move` example.
 
-<RemoteCodeblock 
-  permalink="https://github.com/aptos-labs/aptos-core/blob/77e1d222ebc5e7294e115e0d090c001da1d0e072/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move#L1-L59" 
+<RemoteCodeblock
+  permalink="https://github.com/aptos-labs/aptos-core/blob/afd3706c17bcccfb39a9d6059aecbfa648ed295d/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move#L1-L64"
 />
 
 </Steps>


### PR DESCRIPTION
### Description

Adds a section under`CLI` -> `Get Started` called `Start from template` that demonstrates how to set up a Move package from a template. Uses this command:
```bash
aptos move init --name hello_blockchain --template hello-blockchain
```

![image](https://github.com/user-attachments/assets/996e664e-5fc5-4980-af6a-b481caed17d5)

![image](https://github.com/user-attachments/assets/56f6e7b6-7fae-4c1a-9667-2ada292b5e06)


### Checklist

- Do all Lints pass?
  - [ ] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
