### PR TITLE
Fix CLI installation command

### DIFF
--- a/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
+++ b/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
@@ -13,7 +13,7 @@ For Windows, the easiest way to install the Aptos CLI tool is via Python script.
 ### In PowerShell, run the install script:
 
    ```powershell filename="Terminal"
-   iwr "https://aptos.dev/scripts/install_cli.py" -useb | Select-Object -ExpandProperty Content | python3
+   Invoke-WebRequest -Uri "https://aptos.dev/scripts/install_cli.py" -OutFile "$env:TEMP\install_cli.py"; python3 "$env:TEMP\install_cli.py"
    ```
 
    <Callout type="warning">

--- a/apps/nextra/pages/zh/build/cli/install-cli/install-cli-windows.mdx
+++ b/apps/nextra/pages/zh/build/cli/install-cli/install-cli-windows.mdx
@@ -18,7 +18,7 @@ import {Callout, Steps} from 'nextra/components'
 ### 在 PowerShell 中，运行安装脚本：
 
 ```powershell filename="Terminal"
-iwr "https://aptos.dev/scripts/install_cli.py"  -useb | Select-Object -ExpandProperty Content | python3
+Invoke-WebRequest -Uri "https://aptos.dev/scripts/install_cli.py" -OutFile "$env:TEMP\install_cli.py"; python3 "$env:TEMP\install_cli.py"
 ```
 
    <Callout type="warning">


### PR DESCRIPTION
### Description
I just tried to install the CLI on a fresh Windows installation using an admin powershell and nothing happened with the existing command, it insta fails with an error that flashes too fast to see.

This command works. I also confirmed it works with non admin powershell.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
