### PR TITLE
[object] Remove object burn docs

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/objects.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/objects.mdx
@@ -14,21 +14,21 @@ module my_addr::object_playground {
   use std::signer;
   use std::string::{Self, String};
   use aptos_framework::object::{Self, ObjectCore};
-  
+
   struct MyStruct1 has key {
     message: String,
   }
-  
+
   struct MyStruct2 has key {
     message: String,
   }
- 
+
   entry fun create_and_transfer(caller: &signer, destination: address) {
     // Create object
     let caller_address = signer::address_of(caller);
     let constructor_ref = object::create_object(caller_address);
     let object_signer = object::generate_signer(&constructor_ref);
-    
+
     // Set up the object by creating 2 resources in it
     move_to(&object_signer, MyStruct1 {
       message: string::utf8(b"hello")
@@ -36,7 +36,7 @@ module my_addr::object_playground {
     move_to(&object_signer, MyStruct2 {
       message: string::utf8(b"world")
     });
- 
+
     // Transfer to destination
     let object = object::object_from_constructor_ref<ObjectCore>(
       &constructor_ref
@@ -46,7 +46,7 @@ module my_addr::object_playground {
 }
 ```
 
-During construction, Objects can be configured to be transferrable, burnable, and extensible.
+During construction, Objects can be configured to be transferrable and extensible.
 
 For example, you could use an Object to represent a soulbound NFT by making it only transferrable once, and have it own resources for an image link and metadata. Objects can also own other Objects, so you could implement your own NFT collection Object by transferring several of the soulbound NFTs to it.
 

--- a/apps/nextra/pages/en/build/smart-contracts/objects/using-objects.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/objects/using-objects.mdx
@@ -24,8 +24,8 @@ module my_addr::object_playground {
   entry fun do_something(object: Object<MyAwesomeStruct>) {
     // ...
   }
-  
-  /// All Objects have ObjectCore, so this will only fail if the 
+
+  /// All Objects have ObjectCore, so this will only fail if the
   /// address is not an object
   entry fun do_something_to_object_core(object: Object<ObjectCore>) {
     // ...
@@ -183,7 +183,7 @@ If `ungated_transfer` is **disabled**, then all transfers need to use a special 
 ## Events
 By default, Objects only have a `TransferEvent` which triggers whenever the Object is transferred.
 
-Objects can be extended to have additional events. 
+Objects can be extended to have additional events.
 
 You can use the following functions to create event handles for Objects:
 
@@ -191,7 +191,7 @@ You can use the following functions to create event handles for Objects:
 module 0x1::object {
   /// Create a guid for the object, typically used for events
   public fun create_guid(object: &signer): guid::GUID {}
- 
+
   /// Generate a new event handle.
   public fun new_event_handle<T: drop + store>(object: &signer): event::EventHandle<T> {}
 }
@@ -204,18 +204,18 @@ module 0x42::example {
   use aptos_framework::event;
   use aptos_framework::fungible_asset::FungibleAsset;
   use aptos_framework::object::{Self, Object};
- 
+
   struct LiquidityPoolEventStore has key {
     create_events: event::EventHandle<CreateLiquidtyPoolEvent>,
   }
- 
+
   struct CreateLiquidtyPoolEvent {
     token_a: address,
     token_b: address,
     reserves_a: u128,
     reserves_b: u128,
   }
- 
+
   public entry fun create_liquidity_pool_with_events(
         token_a: Object<FungibleAsset>,
         token_b: Object<FungibleAsset>,
@@ -257,32 +257,6 @@ module 0x42::example {
 ## Modifying Objects after creation
 
 In general, Objects can only be modified with `Refs` generated during construction. See [Creating and Configuring Objects](creating-objects.mdx) for more details on what `Refs` are available, how to generate them, and how to use them. This is how you add additional resources to an Object, delete it, and extend it.
-
-One exception to this is “burning” an Object, which sets a flag so Wallet providers know to not display that Object. This can be used to declutter when an Object is not actually deletable.
-
-```move filename="Example.move"
-module my_addr::object_playground {
-  use aptos_framework::object::{self, Object};
-
-  fun burn_object<T>(owner: &signer, object: Object<T>) {
-    object::burn(owner, object);
-    assert!(object::is_burnt(object) == true, 1);
-  }
-}
-```
-
-If you later decide that you want the Object to be displayed again, you can un-”burn” it.
-
-```move filename="Example.move"
-module my_addr::object_playground {
-  use aptos_framework::object::{self, Object};
-
-  fun unburn_object<T>(owner: &signer, object: object::Object<T>) {
-    object::unburn(owner, object);
-    assert!(object::is_burnt(object) == false, 1);
-  }
-}
-```
 
 ## Example contracts
 


### PR DESCRIPTION
### Description
Removes docs about object burn, as the feature will be removed.

See: https://github.com/aptos-foundation/AIPs/pull/492

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
