### PR TITLE
[legacy-ts-sdk] Add deprecation notice to top of all of the legacy TS SDK Docs

### DIFF
--- a/apps/nextra/pages/en/build/sdks/ts-sdk/_meta.tsx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/_meta.tsx
@@ -27,6 +27,6 @@ export default {
   },
   // Legacy TS SDK should be at the bottom as it is not supposed to be read unless you already know you need it.
   "legacy-ts-sdk": {
-    title: "Legacy TypeScript SDK",
+    title: "Legacy TypeScript SDK (Deprecated)",
   },
 };

--- a/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk.mdx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk.mdx
@@ -4,6 +4,10 @@ title: "Legacy TypeScript SDK"
 
 import { Callout } from 'nextra/components';
 
+<Callout emoji="🚨" type="error">
+  The Legacy TypeScript SDK package `aptos` is deprecated and will be replaced by the new TypeScript SDK. Please refer to the [new TypeScript SDK](/build/sdks/ts-sdk) for the latest features and updates.
+</Callout>
+
 # Legacy TypeScript SDK
 
 <Callout type="info">

--- a/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/migration-guide.mdx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/migration-guide.mdx
@@ -2,7 +2,11 @@
 title: "Migration Guide"
 ---
 
-import { Callout, Tabs } from 'nextra/components';
+import { Callout } from 'nextra/components';
+
+<Callout emoji="🚨" type="error">
+  The Legacy TypeScript SDK package `aptos` is deprecated and will be replaced by the new TypeScript SDK. Please refer to the [new TypeScript SDK](/build/sdks/ts-sdk) for the latest features and updates.
+</Callout>
 
 # TypeScript SDK Migration Guide
 

--- a/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/sdk-client-layer.mdx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/sdk-client-layer.mdx
@@ -4,6 +4,10 @@ title: "API Client Layer"
 
 import { Callout } from 'nextra/components';
 
+<Callout emoji="🚨" type="error">
+  The Legacy TypeScript SDK package `aptos` is deprecated and will be replaced by the new TypeScript SDK. Please refer to the [new TypeScript SDK](/build/sdks/ts-sdk) for the latest features and updates.
+</Callout>
+
 # Legacy TypeScript SDK Client Layer
 
 The API client layer in the SDK provides a robust and reliable communication channel between the client-side application and the blockchain server. It is a component of the SDK that enables developers to interact with the network through the use of application programming interfaces (APIs). The client layer is responsible for making API calls to the network, sending and receiving data to and from the network, and handling any errors or exceptions that may occur during the process.

--- a/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/sdk-client-layer/aptos-client.mdx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/sdk-client-layer/aptos-client.mdx
@@ -1,7 +1,12 @@
 ---
 title: "AptosClient Class"
 ---
+
 import { Callout } from 'nextra/components';
+
+<Callout emoji="🚨" type="error">
+  The Legacy TypeScript SDK package `aptos` is deprecated and will be replaced by the new TypeScript SDK. Please refer to the [new TypeScript SDK](/build/sdks/ts-sdk) for the latest features and updates.
+</Callout>
 
 # Legacy TypeScript AptosClient Class
 

--- a/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/sdk-client-layer/indexer-client.mdx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/sdk-client-layer/indexer-client.mdx
@@ -4,6 +4,10 @@ title: "IndexerClient Class"
 
 import { Callout } from 'nextra/components';
 
+<Callout emoji="🚨" type="error">
+  The Legacy TypeScript SDK package `aptos` is deprecated and will be replaced by the new TypeScript SDK. Please refer to the [new TypeScript SDK](/build/sdks/ts-sdk) for the latest features and updates.
+</Callout>
+
 # Legacy TypeScript IndexerClient Class
 
 The [IndexerClient](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/src/providers/indexer.ts) is responsible for handling the communication between the client-side application and the blockchain network. It uses the [Hasura framework](https://hasura.io/) to generate a set of [GraphQL queries](https://cloud.hasura.io/public/graphiql?endpoint=https://api.mainnet.aptoslabs.com/v1/graphql) that can be used to retrieve data from the blockchain. The queries are optimized for performance and can retrieve data in real-time.

--- a/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/sdk-core-layer.mdx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/sdk-core-layer.mdx
@@ -2,6 +2,12 @@
 title: "Core Layer"
 ---
 
+import { Callout } from 'nextra/components';
+
+<Callout emoji="🚨" type="error">
+  The Legacy TypeScript SDK package `aptos` is deprecated and will be replaced by the new TypeScript SDK. Please refer to the [new TypeScript SDK](/build/sdks/ts-sdk) for the latest features and updates.
+</Callout>
+
 # Legacy TypeScript Core Layer
 
 The core SDK layer exposes the functionalities needed by most applications:

--- a/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/sdk-plugins-layer.mdx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/sdk-plugins-layer.mdx
@@ -2,6 +2,12 @@
 title: "Plugins Layer"
 ---
 
+import { Callout } from 'nextra/components';
+
+<Callout emoji="🚨" type="error">
+  The Legacy TypeScript SDK package `aptos` is deprecated and will be replaced by the new TypeScript SDK. Please refer to the [new TypeScript SDK](/build/sdks/ts-sdk) for the latest features and updates.
+</Callout>
+
 # Legacy TypeScript Plugins Layer
 
 A plugin is a component that can be added to the Legacy TypeScript SDK to extend or enhance its functionality. Plugins are meant to be built to support popular applications on the Aptos network and can be used to add new features, ease the use of the application operations and to customize the user experience.

--- a/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/sdk-tests.mdx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/sdk-tests.mdx
@@ -4,6 +4,10 @@ title: "Tests and Validation"
 
 import { Callout } from 'nextra/components';
 
+<Callout emoji="🚨" type="error">
+  The Legacy TypeScript SDK package `aptos` is deprecated and will be replaced by the new TypeScript SDK. Please refer to the [new TypeScript SDK](/build/sdks/ts-sdk) for the latest features and updates.
+</Callout>
+
 # Legacy TypeScript Tests and Validation
 
 The Legacy TypeScript SDK uses two types of tests, `e2e` and `unit` tests, located under the `src/tests/` folder:

--- a/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/typescript-sdk-overview.mdx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/typescript-sdk-overview.mdx
@@ -5,6 +5,11 @@ title: "TypeScript SDK Architecture"
 # Legacy TypeScript SDK Architecture
 
 import { ThemedImage } from '@components/index'
+import { Callout } from 'nextra/components';
+
+<Callout emoji="🚨" type="error">
+  The Legacy TypeScript SDK package `aptos` is deprecated and will be replaced by the new TypeScript SDK. Please refer to the [new TypeScript SDK](/build/sdks/ts-sdk) for the latest features and updates.
+</Callout>
 
 This document describes the main features and components of the Legacy Aptos TypeScript SDK.
 


### PR DESCRIPTION
### Description
Adds deprecation notice to all legacy SDK pages.  This should redirect users to the new SDK.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
