### PR TITLE
Updates Irys links that were failing link checker

### DIFF
--- a/apps/nextra/pages/en/build/create-aptos-dapp/templates/nft-minting-dapp.mdx
+++ b/apps/nextra/pages/en/build/create-aptos-dapp/templates/nft-minting-dapp.mdx
@@ -6,12 +6,12 @@ import { Callout, FileTree, Steps } from 'nextra/components';
 
 # Create Aptos Dapp NFT Minting Dapp Template
 
-[Digital Assets](../../smart-contracts/digital-asset.mdx) are the NFT standard for Aptos. The NFT minting dapp template provides an end-to-end NFT minting dapp. 
+[Digital Assets](../../smart-contracts/digital-asset.mdx) are the NFT standard for Aptos. The NFT minting dapp template provides an end-to-end NFT minting dapp.
 
 With this dapp, you can:
 1. Create a NFT collection on Aptos.
 2. Modify a pre-made UI to build a NFT minting dapp users can quickly adjust.
-3. Learn how to write a Move contract and front end connected to that contract. 
+3. Learn how to write a Move contract and front end connected to that contract.
 
 You can read more about the Aptos Digital Asset Standard [here](../../smart-contracts/digital-asset.mdx).
 
@@ -40,7 +40,7 @@ Follow the CLI prompts.
 
 ## Create Collection Assets
 
-In order to create a `Collection` using `create-dapp-app`, you will need to create a folder with the following information in it. 
+In order to create a `Collection` using `create-dapp-app`, you will need to create a folder with the following information in it.
 
 <FileTree>
   <FileTree.Folder name="assets" defaultOpen>
@@ -68,9 +68,9 @@ The following steps will break down how to do that.
 All collections are **required** to have the following fields:
 ```json filename="collection.json"
 {
-  "name": "Aptos NFTs",                         
-  "description": "My NFT Collection on Aptos.", 
-  "image": "",            
+  "name": "Aptos NFTs",
+  "description": "My NFT Collection on Aptos.",
+  "image": "",
   "external_url": "https://your_project_url.io"
 }
 
@@ -85,14 +85,14 @@ The `image` field of `collection.json` above will be filled in automatically whe
 
 ### Add all potential NFT images to the `images` folder.
 
-All images must have the same file extension for this template app to work. 
+All images must have the same file extension for this template app to work.
 
 ### Create a folder called `metadata` in the `assets` folder.
 
 ### Add a metadata json file for each NFT image in the `images` folder.
-The metadata files should match the names of the images in the `images` folder. Ex. `1.jpeg` -> `1.json`. 
+The metadata files should match the names of the images in the `images` folder. Ex. `1.jpeg` -> `1.json`.
 
-All fields in the example below other than `attributes` are **required**. 
+All fields in the example below other than `attributes` are **required**.
 
 The `attributes` section is optional, and can contain any key-value pairs.
 
@@ -103,11 +103,11 @@ The `name` field of the metadata.json must be unique for this collection.
 Here is an example of what each metadata file should look like:
 ```json filename="1.json"
 {
-  "description": "nft 1 in collection",            
-  "image": "",                                     
-  "name": "NFT 1",                                 
-  "external_url": "https://your_project_url.io/1", 
-  "attributes": [                                  
+  "description": "nft 1 in collection",
+  "image": "",
+  "name": "NFT 1",
+  "external_url": "https://your_project_url.io/1",
+  "attributes": [
     {
       "trait_type": "optional_trait",
       "value": "1"
@@ -186,8 +186,8 @@ After you have [published the Move contract to chain](#publish-the-move-contract
 npm run dev
 ```
 
-### In the top-right corner, click "Connect a Wallet". 
-Use the same account that you set in `.env` for the `VITE_COLLECTION_CREATOR_ADDRESS`. 
+### In the top-right corner, click "Connect a Wallet".
+Use the same account that you set in `.env` for the `VITE_COLLECTION_CREATOR_ADDRESS`.
 Or, if you use a different account, set the `VITE_COLLECTION_CREATOR_ADDRESS` to the account you sign in with and republish the contract.
 
 <Callout type="warning">
@@ -212,7 +212,7 @@ The rest are optional fields to help customize your mint.
 ### Click "Create Collection"
 When adding the folder, it submits the files to [Irys](https://irys.xyz/), a decentralized asset server, that will store your files.
 
-During the upload process, you will need to sign two messages to approve file uploading to Irys. Additionally, you may need to fund an Irys node. Read more about the process [here](https://arweave-tools.irys.xyz/tutorials/nfts/uploading-nfts).
+During the upload process, you will need to sign two messages to approve file uploading to Irys. Additionally, you may need to fund an Irys node. Read more about the process [here](https://docs.irys.xyz/build/d/guides/uploading-nfts).
 
 ### Once you approve the transaction, you have successfully created a Collection on Aptos!
 
@@ -220,11 +220,11 @@ During the upload process, you will need to sign two messages to approve file up
 
 ## Customizing the Front-End
 
-Most data on the front end is customizable in `frontend/config.ts`. 
+Most data on the front end is customizable in `frontend/config.ts`.
 
 ### Set the `collection_address` config
 
-In order to add a collection to the public mint page, set `collection_address` in `.env` with the collection address. 
+In order to add a collection to the public mint page, set `collection_address` in `.env` with the collection address.
 
 You can use a collection that you have minted using the tool by going to the "My Collections" page and copying its address.
 
@@ -278,9 +278,9 @@ Creating a collection on mainnet follows the same flow as creating a collection 
 
 ## Deploy to a live server
 
-`create-aptos-dapp` provides an npm command to easily deploy the static site to [Vercel](https://vercel.com/home). 
+`create-aptos-dapp` provides an npm command to easily deploy the static site to [Vercel](https://vercel.com/home).
 
-At the root of the folder, simply run 
+At the root of the folder, simply run
 
 ```bash filename="Terminal"
 npm run deploy

--- a/apps/nextra/pages/en/build/create-aptos-dapp/templates/token-minting-dapp.mdx
+++ b/apps/nextra/pages/en/build/create-aptos-dapp/templates/token-minting-dapp.mdx
@@ -6,12 +6,12 @@ import { Callout, FileTree, Steps } from 'nextra/components';
 
 # Create Aptos Dapp Token Minting Dapp Template
 
-The Token minting dapp template provides an end-to-end [Fungible Asset](../../smart-contracts/digital-asset.mdx) minting dapp. 
+The Token minting dapp template provides an end-to-end [Fungible Asset](../../smart-contracts/digital-asset.mdx) minting dapp.
 
 With this dapp, you can:
 1. Create a Fungible Asset on Aptos.
 2. Modify a pre-made UI to build a Token minting dapp users can quickly adjust.
-3. Learn how to write a Move contract and front end connected to that contract. 
+3. Learn how to write a Move contract and front end connected to that contract.
 
 Read more about the [Aptos Fungible Asset Standard](../../smart-contracts/digital-asset.mdx)
 
@@ -78,8 +78,8 @@ After you have [published the Move contract to chain](#publish-the-move-contract
 npm run dev
 ```
 
-### In the top-right corner, click "Connect a Wallet". 
-Use the same account that you set in `.env` for the `VITE_FA_CREATOR_ADDRESS`. 
+### In the top-right corner, click "Connect a Wallet".
+Use the same account that you set in `.env` for the `VITE_FA_CREATOR_ADDRESS`.
 Or, if you use a different account, set the `VITE_FA_CREATOR_ADDRESS` to the account you sign in with and republish the contract.
 
 <Callout type="warning">
@@ -105,7 +105,7 @@ The rest are optional fields to help customize your mint.
 ### Click "Create Asset"
 When adding the image, it submits the file to [Irys](https://irys.xyz/), a decentralized asset server, that will store your files.
 
-During the upload process, you will need to sign a message to approve file uploading to Irys. Additionally, you may need to fund an Irys node. Read more about the process [here](https://arweave-tools.irys.xyz/tutorials/nfts/uploading-nfts).
+During the upload process, you will need to sign a message to approve file uploading to Irys. Additionally, you may need to fund an Irys node. Read more about the process [here](https://docs.irys.xyz/build/d/guides/uploading-nfts).
 
 ### Once you approve the transaction, you have successfully created a fungible asset on Aptos!
 
@@ -113,11 +113,11 @@ During the upload process, you will need to sign a message to approve file uploa
 
 ## Customizing the Front-End
 
-Most data on the front end is customizable in `frontend/config.ts`. 
+Most data on the front end is customizable in `frontend/config.ts`.
 
 ### Set the `fa_address` config
 
-In order to add a fungible asset to the public mint page, set `fa_address` in `.env` with the asset address. 
+In order to add a fungible asset to the public mint page, set `fa_address` in `.env` with the asset address.
 
 You can use an assset that you have minted using the tool by going to the "My Assets" page and copying its address.
 
@@ -170,9 +170,9 @@ Creating a asset on mainnet is the same flow as creating on testnet, but we need
 
 ## Deploy to a live server
 
-`create-aptos-dapp` provides an npm command to easily deploy the static site to [Vercel](https://vercel.com/home). 
+`create-aptos-dapp` provides an npm command to easily deploy the static site to [Vercel](https://vercel.com/home).
 
-At the root of the folder, simply run 
+At the root of the folder, simply run
 
 ```bash filename="Terminal"
 npm run deploy


### PR DESCRIPTION
### Description
Updates links to Irys.xyz that were broken and pointing to an old version of their docs. This should also fix the `linkChecker` job.

The only actual change is 2 lines where I changed the link. I think Webstorm must have taken it upon itself to trim lines.

### Checklist

- Do all Lints pass?
  - [ ] Have you ran `pnpm spellcheck`?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
