### PR TITLE
[move-2] Add documentation about destroying enum values

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/book/enums.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/enums.mdx
@@ -167,7 +167,7 @@ enum VersionedData has key {
 }
 
 data.name
- // ^^^^^ compile time error that `name` field selection is ambigious
+ // ^^^^^ compile time error that `name` field selection is ambiguous
 ```
 
 ## Using Enums Patterns in Lets
@@ -181,6 +181,31 @@ let V1{name} = data;
 
 Unpacking the enum value will abort if the variant is not the expected one. To ensure that all variants of an enum are handled, a `match` expression is recommended instead of a `let`. The `match` is checked at compile time, ensuring that all variants are covered. In some cases, tools like the Move Prover can be used to verify that unexpected aborts cannot happen with a `let`.
 
+## Destroying Enums via Pattern Matching
+
+Similar to struct values, enum values can be destroyed by explicitly unpacking them. Enums can be unpacked with pattern matching in a `match` expression, enum pattern in a `let` binding, or enum pattern in an assignment.
+
+```move
+// Note: `Shape` has no `drop` ability, so must be destroyed with explicit unpacking.
+enum Shape {
+    Circle{radius: u64},
+    Rectangle{width: u64, height: u64}
+}
+
+fun destroy_empty(self: Shape) {
+    match (self) {
+        Shape::Circle{radius} => assert!(radius == 0),
+        Shape::Rectangle{width, height: _} => assert!(width == 0),
+    }
+}
+
+fun example_destroy_shapes() {
+    let c = Shape::Circle{radius: 0};
+    let r = Shape::Rectangle{width: 0, height: 0};
+    c.destroy_empty();
+    r.destroy_empty();
+}
+```
 
 ## Enum Type Upgrade Compatibility 
 


### PR DESCRIPTION
### Description

In this PR, we add documentation about destroying (non-droppable) enum values.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
