### PR TITLE
Add "has key" to structs and pass constructor_ref by reference

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/objects.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/objects.mdx
@@ -15,11 +15,11 @@ module my_addr::object_playground {
   use std::string::{Self, String};
   use aptos_framework::object::{Self, ObjectCore};
   
-  struct MyStruct1 {
+  struct MyStruct1 has key {
     message: String,
   }
   
-  struct MyStruct2 {
+  struct MyStruct2 has key {
     message: String,
   }
  
@@ -27,7 +27,7 @@ module my_addr::object_playground {
     // Create object
     let caller_address = signer::address_of(caller);
     let constructor_ref = object::create_object(caller_address);
-    let object_signer = object::generate_signer(constructor_ref);
+    let object_signer = object::generate_signer(&constructor_ref);
     
     // Set up the object by creating 2 resources in it
     move_to(&object_signer, MyStruct1 {


### PR DESCRIPTION
  ### Description

This PR adds the key ability to MyStruct1 and MyStruct2 and passes constructor_ref by reference as generate_signer expects a 
 reference to ConstructorRef

  ### Checklist
  
  - Do all Lints pass?
    - [x] Have you ran `pnpm spellcheck`?
    - [x] Have you ran `pnpm fmt`?
    - [x] Have you ran `pnpm lint`?
