### PR TITLE
fix TS syntax error: to `faucetClient.fund.fund({ ... })`

### DIFF
--- a/apps/nextra/pages/en/build/apis/faucet-api.mdx
+++ b/apps/nextra/pages/en/build/apis/faucet-api.mdx
@@ -64,7 +64,7 @@ async function callFaucet(amount: number, address: string): Promise<string []> {
     amount,
     address,
   };
-  const response = await faucetClient.fund({ requestBody: request });
+  const response = await faucetClient.fund.fund({ requestBody: request });
   return response.txn_hashes;
 }
 ```


### PR DESCRIPTION
# Before

`faucetClient.fund({...})`

```error
TypeError: faucetClient.fund is not a function
```

<img width="594" alt="image" src="https://github.com/user-attachments/assets/f327707f-d549-498a-9714-3424e7c62883">

# Reason

```
(property) AptosFaucetClient.fund: FundService
readonly fund: FundService;
```

<img width="790" alt="image" src="https://github.com/user-attachments/assets/b353f3a3-5ec4-4f68-afd4-f73070ca1c43">


# After

`faucetClient.fund.fund({...})`

```success
{
    "txn_hashes": [
        "1fb395065a4f2ccd7dcc8d330655be278111b34366873b896181de9eff6852ad"
    ],
    "__headers": {
        "content-length": "83",
        "content-type": "application/json; charset=utf-8"
    }
}
```

# Test code

```ts
 async function callFaucet(
    amount: number,
    address: string
  ): Promise<string[]> {
    const faucetClient = new AptosFaucetClient({
      BASE: 'https://faucet.testnet.aptoslabs.com',
    })

    const request: FundRequest = {
      amount,
      address,
    }

    try {
      const response = await faucetClient.fund.fund({ requestBody: request })
      console.log(response)
      if ('txn_hashes' in response) {
        return response.txn_hashes
      } else {
        throw new Error('Funding failed: ' + response)
      }
    } catch (error) {
      console.error(error)
      throw error
    }
  }
```