### PR TITLE
[Move Book] Add documentation for op equal

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/book/variables.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/variables.mdx
@@ -619,6 +619,48 @@ script {
 
 For more details, see [Move references](references.mdx).
 
+### Compound Assignments
+
+_Since language version 2.1_
+
+Move also supports compound assignment operators.
+
+| Syntax | Description                                                |
+| ------ | ---------------------------------------------------------- |
+| `+=`   | Performs addition and update the left-hand value           |
+| `-=`   | Performs subtraction and update the left-hand value        |
+| `*=`   | Performs multiplication and update the left-hand value     |
+| `%=`   | Performs modular division and update the left-hand value   |
+| `/=`   | Performs truncating division and update the left-hand value|
+| `&=`   | Performs bitwise and and update the left-hand value        |
+| `\|=`   | Performs bitwise or and update the left-hand value         |
+| `^=`   | Performs bitwise xor and update the left-hand value        |
+| `<<=`  | Performs shift left and update the left-hand value         |
+| `>>=`  | Performs shift right and update the left-hand value        |
+
+For `e1 op= e2`, the **modifying operand** `e2` is evaluated first, followed by the **assigned operand** `e1`. The result of performing `op` on the operand values is then stored in the left-hand side location. The assigned operand is only evaluated once.
+
+```move
+module 0x42::example {
+  struct S { f: u64 }
+
+  fun example() {
+    let x = 41;
+    x += 1;
+    assert!(x == 42);
+
+    let y = 41;
+    let p = &mut y;
+    *p += 1;
+    assert!(*p == 42);
+
+    let z = S { f: 41 };
+    z.f += 1;
+    assert!(z.f == 42);
+  }
+}
+```
+
 ## Scopes
 
 Any local declared with `let` is available for any subsequent expression, _within that scope_.

--- a/apps/nextra/pages/en/build/smart-contracts/book/variables.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/variables.mdx
@@ -623,22 +623,27 @@ For more details, see [Move references](references.mdx).
 
 _Since language version 2.1_
 
-Move also supports compound assignment operators.
+Move also supports compound assignment operators. These are like an assignment to a variable,
+or a mutation through a reference, except that the assigned location must already have a value,
+which is read and operated on before being stored back into the location.
+Currently these are only applicable to numeric values.
 
-| Syntax | Description                                                 |
-| ------ | ----------------------------------------------------------  |
-| `+=`   | Performs addition and update the left-hand value            |
-| `-=`   | Performs subtraction and update the left-hand value         |
-| `*=`   | Performs multiplication and update the left-hand value      |
-| `%=`   | Performs modular division and update the left-hand value    |
-| `/=`   | Performs truncating division and update the left-hand value |
-| `&=`   | Performs bitwise and and update the left-hand value         |
-| `\|=`  | Performs bitwise or and update the left-hand value          |
-| `^=`   | Performs bitwise xor and update the left-hand value         |
-| `<<=`  | Performs shift left and update the left-hand value          |
-| `>>=`  | Performs shift right and update the left-hand value         |
+| Syntax | Description                                                  |
+| ------ | ------------------------------------------------------------ |
+| `+=`   | Performs addition and updates the left-hand value            |
+| `-=`   | Performs subtraction and updates the left-hand value         |
+| `*=`   | Performs multiplication and updates the left-hand value      |
+| `%=`   | Performs modular division and updates the left-hand value    |
+| `/=`   | Performs truncating division and updates the left-hand value |
+| `&=`   | Performs bitwise and and updates the left-hand value         |
+| `\|=`  | Performs bitwise or and updates the left-hand value          |
+| `^=`   | Performs bitwise xor and updates the left-hand value         |
+| `<<=`  | Performs shift left and updates the left-hand value          |
+| `>>=`  | Performs shift right and updates the left-hand value         |
 
-For `e1 op= e2`, the **modifying operand** `e2` is evaluated first, followed by the **assigned operand** `e1`. The result of performing `op` on the operand values is then stored in the left-hand side location. The assigned operand is only evaluated once.
+For `e1 += e2`, the **modifying operand** `e2` is evaluated first, followed by the **assigned operand** `e1`.
+The result of performing `+` on the operand values is then stored in the left-hand side location.
+The assigned operand is only evaluated once. Similarly for all other operations listed in the table above.
 
 ```move
 module 0x42::example {

--- a/apps/nextra/pages/en/build/smart-contracts/book/variables.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/variables.mdx
@@ -633,7 +633,7 @@ Move also supports compound assignment operators.
 | `%=`   | Performs modular division and update the left-hand value   |
 | `/=`   | Performs truncating division and update the left-hand value|
 | `&=`   | Performs bitwise and and update the left-hand value        |
-| `\|=`   | Performs bitwise or and update the left-hand value         |
+| `\|=`   | Performs bitwise or and update the left-hand value        |
 | `^=`   | Performs bitwise xor and update the left-hand value        |
 | `<<=`  | Performs shift left and update the left-hand value         |
 | `>>=`  | Performs shift right and update the left-hand value        |

--- a/apps/nextra/pages/en/build/smart-contracts/book/variables.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/variables.mdx
@@ -625,18 +625,18 @@ _Since language version 2.1_
 
 Move also supports compound assignment operators.
 
-| Syntax | Description                                                |
-| ------ | ---------------------------------------------------------- |
-| `+=`   | Performs addition and update the left-hand value           |
-| `-=`   | Performs subtraction and update the left-hand value        |
-| `*=`   | Performs multiplication and update the left-hand value     |
-| `%=`   | Performs modular division and update the left-hand value   |
-| `/=`   | Performs truncating division and update the left-hand value|
-| `&=`   | Performs bitwise and and update the left-hand value        |
-| `\|=`   | Performs bitwise or and update the left-hand value        |
-| `^=`   | Performs bitwise xor and update the left-hand value        |
-| `<<=`  | Performs shift left and update the left-hand value         |
-| `>>=`  | Performs shift right and update the left-hand value        |
+| Syntax | Description                                                 |
+| ------ | ----------------------------------------------------------  |
+| `+=`   | Performs addition and update the left-hand value            |
+| `-=`   | Performs subtraction and update the left-hand value         |
+| `*=`   | Performs multiplication and update the left-hand value      |
+| `%=`   | Performs modular division and update the left-hand value    |
+| `/=`   | Performs truncating division and update the left-hand value |
+| `&=`   | Performs bitwise and and update the left-hand value         |
+| `\|=`  | Performs bitwise or and update the left-hand value          |
+| `^=`   | Performs bitwise xor and update the left-hand value         |
+| `<<=`  | Performs shift left and update the left-hand value          |
+| `>>=`  | Performs shift right and update the left-hand value         |
 
 For `e1 op= e2`, the **modifying operand** `e2` is evaluated first, followed by the **assigned operand** `e1`. The result of performing `op` on the operand values is then stored in the left-hand side location. The assigned operand is only evaluated once.
 


### PR DESCRIPTION
### Description

Add documentation for the op equals https://github.com/aptos-labs/aptos-core/pull/14583.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
