### PR TITLE
[unity] Move old Unity (OpenDive) docs and added the new Unity docs

### DIFF
--- a/apps/nextra/pages/en/build/sdks/community-sdks/_meta.tsx
+++ b/apps/nextra/pages/en/build/sdks/community-sdks/_meta.tsx
@@ -2,4 +2,7 @@ export default {
   "swift-sdk": {
     title: "Swift SDK",
   },
+  "unity-opendive-sdk": {
+    title: "Unity SDK (Legacy)",
+  },
 };

--- a/apps/nextra/pages/en/build/sdks/community-sdks/unity-opendive-sdk.mdx
+++ b/apps/nextra/pages/en/build/sdks/community-sdks/unity-opendive-sdk.mdx
@@ -1,0 +1,65 @@
+---
+title: "Unity SDK (Legacy)"
+---
+
+import { Callout } from "nextra/components";
+
+<Callout type="warning" emoji="❗">
+  This SDK is currently unmaintained. You can use the official [Unity
+  SDK](../unity-official-sdk.mdx) for the latest features.
+</Callout>
+
+# Unity SDK
+
+The [Aptos Unity SDK](https://github.com/aptos-labs/Aptos-Unity-SDK) is a .NET implementation of the [Aptos SDK](../sdks.mdx), compatible with .NET Standard 2.0 and .NET 4.x for Unity. The goal of this SDK is to provide a set of tools for developers to build multi-platform applications (mobile, desktop, web, VR) using the Unity game engine and the Aptos blockchain infrastructure.
+
+See the post [Aptos Labs brings Web3 to Gaming with its new SDK for Unity developers](https://medium.com/aptoslabs/aptos-labs-brings-web3-to-gaming-with-its-new-sdk-for-unity-developers-e6544bdf9ba9) and the [Technical details](https://github.com/aptos-labs/Aptos-Unity-SDK#technical-details) section of the Unity SDK README for all the features offered to game developers by the Aptos Unity SDK.
+
+## User flows
+
+The Aptos Unity SDK supports these use cases:
+
+- _Progressive onboarding flow_ in which users can log into a game by email. In this flow, transactions are proxied, and Aptos uses a distributed key system. The users can then onboard to a full custodial wallet if desired.
+- _In-game non-custodial wallet integration_ in which game developers have the option to allow users to create full non-custodial wallets in the games.
+- _Off-game non-custodial wallet integration_ in which game developers may allow users to connect to a desktop wallet or a mobile wallet within the game or create burner wallets from the parent wallet seamlessly.
+
+## Prerequisites
+
+### Supported Unity versions
+
+| Supported Version: | Tested |
+| ------------------ | ------ |
+| 2021.3.x           | ✅     |
+| 2022.2.x           | ✅     |
+
+| Windows | macOS | iOS | Android | WebGL |
+| ------- | ----- | --- | ------- | ----- |
+| ✅      | ✅    | ✅  | ✅      | ✅    |
+
+### Dependencies
+
+> As of Unity 2021.x.x, Newtonsoft Json is a common dependency. Prior versions of Unity require installing Newtonsoft.
+
+- [Chaos.NaCl.Standard](https://www.nuget.org/packages/Chaos.NaCl.Standard/)
+- Microsoft.Extensions.Logging.Abstractions.1.0.0 — required by NBitcoin.7.0.22
+- Newtonsoft.Json
+- NBitcoin.7.0.22
+- [Portable.BouncyCastle](https://www.nuget.org/packages/Portable.BouncyCastle)
+- Zxing
+
+## Install the Unity SDK
+
+You may install the Unity SDK either through our `unitypackage` or the [Unity Package Manager](https://docs.unity3d.com/Manual/Packages.html).
+
+### Install by `unitypackage`
+
+1. Start Unity.
+2. Download the latest `Aptos.Unity.unitypackage` file from the [Unity Asset Store](https://assetstore.unity.com/packages/decentralization/aptos-sdk-244713).
+3. Click **Assets** → **Import Packages** → **Custom Package** and select the downloaded file.
+
+### Install by Unity Package Manager
+
+1. Open the [Unity Package Manager](https://docs.unity3d.com/Manual/upm-ui.html) window.
+2. Click the add **+** button in the top status bar.
+3. Select _Add package from git URL_ from the dropdown menu.
+4. Enter the URL *https://github.com/aptos-labs/Aptos-Unity-SDK.git* and click **Add**.

--- a/apps/nextra/pages/en/build/sdks/dotnet-sdk.mdx
+++ b/apps/nextra/pages/en/build/sdks/dotnet-sdk.mdx
@@ -14,7 +14,7 @@ import { Callout } from "nextra/components";
 
 # Aptos .NET SDK (Beta)
 
-Integrate Aptos web3 capabilities within your .NET applications. The goal of this SDK is to provide a set of tools
+Integrate Aptos Web3 capabilities within your .NET applications. The goal of this SDK is to provide a set of tools
 for developers to build multi-platform applications across compatible game engines and platforms.
 
 **Supported Features**

--- a/apps/nextra/pages/en/build/sdks/dotnet-sdk/unity-integration.mdx
+++ b/apps/nextra/pages/en/build/sdks/dotnet-sdk/unity-integration.mdx
@@ -16,42 +16,28 @@ import { Card, Cards } from "@components/index";
 
 This guide will walk you through the process of integrating the Aptos .NET SDK.
 
-<Callout type="info" emoji="ℹ️">
-  We are currently working on a `.unitypackage` for Unity developers. In the
-  meantime, you can use the [NuGet](https://github.com/GlitchEnzo/NuGetForUnity)
-  package manager to install the SDK into your Unity project.
-</Callout>
-
 <Steps>
 
-### Install NuGetForUnity
+### Install the Aptos Unity SDK
+
+#### Option 1: Import via Unity Package Manager (UPM)
 
 1. Open Package Manager window (Window | Package Manager)
 2. Click + button on the upper-left of a window, and select _Add package from git URL..._
 3. Enter the following URL and click Add button
 
+```bash
+https://github.com/aptos-labs/unity-sdk.git?path=/Packages/com.aptoslabs.aptos-unity-sdk
 ```
-https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity
-```
 
-### Open NuGetForUnity and install the Aptos SDK
+#### Option 2: Import via `unitypackage`
 
-4. Click on `Manage NuGet Packages` from the `NuGet` menu in the Unity Editor.
-
-<div className="border dark:border-white/30 w-fit rounded-md overflow-clip shadow-md max-w-lg">
-  ![launch-nuget](https://i.imgur.com/DSvM5BM.png)
-</div>
-
-5. Make sure to turn on `Show Prerelease` in the top left of the manager window.
-6. Search for Aptos and install the package.
-
-<div className="border dark:border-white/30 w-fit rounded-md overflow-clip shadow-md max-w-lg">
-  ![search-aptos](https://i.imgur.com/8UTvYtj.png)
-</div>
+1. Go to the [`aptos-labs/unity-sdk Releases`](https://github.com/aptos-labs/unity-sdk/releases) and download the latest release.
+2. Drag and drop the `.unitypackage` file into your Unity project.
 
 ### Use the Aptos SDK
 
-7. Import the `Aptos` namespace in your C# script and use the SDK.
+Import the `Aptos` namespace in your C# script and use the SDK.
 
 ```csharp {2-2,8-8,11-15}
 using UnityEngine;
@@ -82,11 +68,28 @@ you can start building your game and interacting with the Aptos blockchain. Belo
 are some resources to help you get started.
 
 <Cards className="xl:grid-cols-2">
-  <Card href="./getting-started" className="col-span-2 flex flex-row gap-4">
+  <Card href="./getting-started" className="flex flex-row gap-4">
     <div className="flex flex-col gap-2">
       <Card.Title>Getting Started</Card.Title>
       <Card.Description>
         Begin developing using the Aptos .NET SDK.
+      </Card.Description>
+    </div>
+  </Card>
+  <Card href="../unity-sdk" className="flex flex-row gap-4">
+    <div className="flex flex-col gap-2">
+      <Card.Title>Unity SDK</Card.Title>
+      <Card.Description>Overview of the Unity SDK.</Card.Description>
+    </div>
+  </Card>
+  <Card
+    href="https://github.com/aptos-labs/aptos-unity-starter"
+    className="col-span-2 flex flex-row gap-4"
+  >
+    <div className="flex flex-col gap-2">
+      <Card.Title>Aptos Wallet Starter</Card.Title>
+      <Card.Description>
+        Example Unity project with an integration of the Aptos Unity SDK.
       </Card.Description>
     </div>
   </Card>

--- a/apps/nextra/pages/en/build/sdks/unity-sdk.mdx
+++ b/apps/nextra/pages/en/build/sdks/unity-sdk.mdx
@@ -2,64 +2,65 @@
 title: "Unity SDK"
 ---
 
+import { Card, Cards } from "@components/index";
 import { Callout } from "nextra/components";
 
 <Callout type="warning" emoji="❗">
-  This SDK is currently unmaintained. You can use the [.NET
-  SDK](./dotnet-sdk.mdx) for the latest features.
+  This SDK is currently in beta. Please report any issues you encounter by
+  creating an issue in the
+  [aptos-labs/unity-sdk](https://github.com/aptos-labs/unity-sdk) repository.
 </Callout>
 
-# Unity SDK
+# Aptos Unity SDK (Beta)
 
-The [Aptos Unity SDK](https://github.com/aptos-labs/Aptos-Unity-SDK) is a .NET implementation of the [Aptos SDK](../sdks.mdx), compatible with .NET Standard 2.0 and .NET 4.x for Unity. The goal of this SDK is to provide a set of tools for developers to build multi-platform applications (mobile, desktop, web, VR) using the Unity game engine and the Aptos blockchain infrastructure.
+Integrate Aptos Web3 capabilities within your Unity applications. The goal of this SDK is to provide a set of tools
+for developers to build Web3 games using the Unity game engine.
 
-See the post [Aptos Labs brings Web3 to Gaming with its new SDK for Unity developers](https://medium.com/aptoslabs/aptos-labs-brings-web3-to-gaming-with-its-new-sdk-for-unity-developers-e6544bdf9ba9) and the [Technical details](https://github.com/aptos-labs/Aptos-Unity-SDK#technical-details) section of the Unity SDK README for all the features offered to game developers by the Aptos Unity SDK.
+**Supported Features**
 
-## User flows
+- Support for the [Aptos .NET SDK](../dotnet-sdk.mdx)
 
-The Aptos Unity SDK supports these use cases:
+  > - Binary Canonical Serialization (BCS) encoding and decoding
+  > - Ed25519, SingleKey, MultiKey, and Keyless signer support
+  > - Utilities for transaction building, signing, and submission
+  > - Abstractions over the Aptos Fullnode and Indexer APIs
+  > - Aptos Names (ANS) support for resolution and lookup
 
-- _Progressive onboarding flow_ in which users can log into a game by email. In this flow, transactions are proxied, and Aptos uses a distributed key system. The users can then onboard to a full custodial wallet if desired.
-- _In-game non-custodial wallet integration_ in which game developers have the option to allow users to create full non-custodial wallets in the games.
-- _Off-game non-custodial wallet integration_ in which game developers may allow users to connect to a desktop wallet or a mobile wallet within the game or create burner wallets from the parent wallet seamlessly.
+**Compatibility**
 
-## Prerequisites
+| .NET Version      | Supported |
+| ----------------- | --------- |
+| .NET Standard 2.1 | ✅        |
 
-### Supported Unity versions
+## Installation
 
-| Supported Version: | Tested |
-| ------------------ | ------ |
-| 2021.3.x           | ✅     |
-| 2022.2.x           | ✅     |
+### Install via Unity Package Manager (UPM)
 
-| Windows | macOS | iOS | Android | WebGL |
-| ------- | ----- | --- | ------- | ----- |
-| ✅      | ✅    | ✅  | ✅      | ✅    |
+1. Open the Unity Package Manager (`Window` > `Package Manager`).
+2. Click on the `+` button and select `Add package from git URL...`.
+3. Enter the URL of the Aptos Unity SDK path in this repository:
 
-### Dependencies
+```bash
+https://github.com/aptos-labs/unity-sdk.git?path=/Packages/com.aptoslabs.aptos-unity-sdk
+```
 
-> As of Unity 2021.x.x, Newtonsoft Json is a common dependency. Prior versions of Unity require installing Newtonsoft.
+### Install via `unitypackage`
 
-- [Chaos.NaCl.Standard](https://www.nuget.org/packages/Chaos.NaCl.Standard/)
-- Microsoft.Extensions.Logging.Abstractions.1.0.0 — required by NBitcoin.7.0.22
-- Newtonsoft.Json
-- NBitcoin.7.0.22
-- [Portable.BouncyCastle](https://www.nuget.org/packages/Portable.BouncyCastle)
-- Zxing
+1. Go to the [`aptos-labs/unity-sdk Releases`](https://github.com/aptos-labs/unity-sdk/releases) and download the latest release.
+2. Drag and drop the `.unitypackage` file into your Unity project.
 
-## Install the Unity SDK
+## Resources
 
-You may install the Unity SDK either through our `unitypackage` or the [Unity Package Manager](https://docs.unity3d.com/Manual/Packages.html).
-
-### Install by `unitypackage`
-
-1. Start Unity.
-2. Download the latest `Aptos.Unity.unitypackage` file from the [Unity Asset Store](https://assetstore.unity.com/packages/decentralization/aptos-sdk-244713).
-3. Click **Assets** → **Import Packages** → **Custom Package** and select the downloaded file.
-
-### Install by Unity Package Manager
-
-1. Open the [Unity Package Manager](https://docs.unity3d.com/Manual/upm-ui.html) window.
-2. Click the add **+** button in the top status bar.
-3. Select _Add package from git URL_ from the dropdown menu.
-4. Enter the URL *https://github.com/aptos-labs/Aptos-Unity-SDK.git* and click **Add**.
+<Cards className="xl:grid-cols-2">
+  <Card
+    href="https://github.com/aptos-labs/aptos-unity-starter"
+    className="col-span-2 flex flex-row gap-4"
+  >
+    <div className="flex flex-col gap-2">
+      <Card.Title>Aptos Wallet Starter</Card.Title>
+      <Card.Description>
+        Example Unity project with an integration of the Aptos Unity SDK.
+      </Card.Description>
+    </div>
+  </Card>
+</Cards>


### PR DESCRIPTION
### Description
Move the old Unity docs to the `Community SDKs` and added new Unity docs for the new package. Re-wrote the old .NET Unity integration instructions for the new package.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
