### PR TITLE
fix invalid JSON

### DIFF
--- a/apps/nextra/pages/en/build/indexer/fungible-asset-balances.mdx
+++ b/apps/nextra/pages/en/build/indexer/fungible-asset-balances.mdx
@@ -24,7 +24,7 @@ Try it yourself! Adjust the query variables below in the editor to fetch data fo
 }`}
   variables={`{
   "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
-  "token_standard": "v1"
+  "token_standard": "v1",
   "offset": 0
 }`}
 />


### PR DESCRIPTION
### Fix

Error: Variables are invalid JSON: Expected ',' or '}' after property value in JSON at position 106 (line 4 column 1).

### Before

Variables are invalid JSON: Expected ',' or '}' after property value in JSON at position 106 (line 4 column 1).

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/202f241c-b3c6-467b-8229-768b6f8c1e69">


### After

<img width="1139" alt="image" src="https://github.com/user-attachments/assets/51f0e33e-9965-4f18-b20c-8ded2bfa5a95">


### Description

### Checklist

- Do all Lints pass?
  - [ ] Have you ran `pnpm spellcheck`?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
