### PR TITLE
[move book] Adding docs for 2.1 language release

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/book/SUMMARY.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/SUMMARY.mdx
@@ -7,7 +7,7 @@
 
 ## Language Release Notes
 
-- [Move 2.0](move-2.0.mdx)
+- [Move 2](move-2.mdx)
 
 ## Primitive Types
 

--- a/apps/nextra/pages/en/build/smart-contracts/book/_meta.tsx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/_meta.tsx
@@ -2,8 +2,8 @@ export default {
   SUMMARY: {
     title: "Summary",
   },
-  "move-2.0": {
-    title: "Move 2.0 Release Notes",
+  "move-2": {
+    title: "Move 2 Release Notes",
   },
   "---getting-started---": {
     type: "separator",

--- a/apps/nextra/pages/en/build/smart-contracts/book/loops.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/loops.mdx
@@ -259,3 +259,28 @@ script {
   }
 }
 ```
+
+## Loop Labels
+
+_Since language version 2.1_
+
+A `while` or `loop` statement can have a label which can be referred to by a `break` or `continue` statement. In the presence of nested loops, this allows to refer to outer loops. Example:
+
+```move
+script {
+  fun example(x: u64): u64 {
+    'label1: while (x > 10) {
+      loop {
+        if (x % 2 == 0) {
+          x -= 1;
+          continue 'label1;
+        } else if (x < 10) {
+          break 'label1
+        } else
+          x -= 2
+      }
+    };
+    x
+  }
+}
+```

--- a/apps/nextra/pages/en/build/smart-contracts/book/move-2.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/move-2.mdx
@@ -1,7 +1,18 @@
-# Move 2.0 Language Release
+# Move 2 Release Notes
 
-The Move 2.0 language release adds a number of new features to Move. The documentation of those features is integrated into the book, and marked in text with "_Since language version 2.0_". This section gives an overview of the new features and links to the documentation:
+The Move 2 language releases are described on this page. The reference documentation of the new features is integrated into the book, and marked in the text with "_Since language version 2.n_".
 
+## Move 2.1 
+
+The Move 2.1 language release adds the following features to Move:
+
+- **Compound Assignments** One can now use `x += n`, `x -= n`, etc. to combine assignments and arithmetic operations. See [reference doc here](variables.mdx#compound-assignments) for the supported operations.
+
+- **Loop Labels** One can now use labels for loops and have a `break` or `continue` expression refer to those labels. This allows to continue or break outer loops from within nested loops. See [reference doc here](loops.mdx#loop-labels).
+
+## Move 2.0 
+
+The Move 2.0 language release adds the following features to Move:
 
 - **Enum Types** add the option to define different variants of data layout in one storable type. They are documented in the [Enum Type section](enums.mdx).
 

--- a/apps/nextra/pages/en/build/smart-contracts/compiler_v2.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/compiler_v2.mdx
@@ -6,7 +6,7 @@ title: "Move On Aptos Compiler (beta)"
 
 The Move on Aptos compiler (codename 'compiler v2') is a new tool which translates Move source code into Move bytecode. It unifies the architectures of the Move compiler and the Move Prover, enabling faster innovation in the Move language. It also offers new tools for defining code optimizations which can be leveraged to generate more gas efficient code for Move programs.
 
-The new compiler supports Move 2, the latest revision of the Move language. Head over to the [release page in the book](book/move-2.0.mdx) to learn more about the new features in Move 2. You can select both this language version and the new compiler by using `aptos move compile --move-2`.
+The new compiler supports Move 2, the latest revision of the Move language. Head over to the [release page in the book](book/move-2.mdx) to learn more about the new features in Move 2. You can select both this language version and the new compiler by using `aptos move compile --move-2`.
 
 ## Compiler v2 Release State
 


### PR DESCRIPTION
### Description

Adds loop label documentation and updates the release notes.


### Checklist

CI will show, those do not work on my machine locally.

- Do all Lints pass?
  - [ ] Have you ran `pnpm spellcheck`?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
