### PR TITLE
[redirect] Point move-2.0 to move-2

### DIFF
--- a/apps/nextra/next.config.mjs
+++ b/apps/nextra/next.config.mjs
@@ -1741,6 +1741,11 @@ export default withBundleAnalyzer(
         destination: "/en/build/sdks/community-sdks/kotlin-sdk",
         permanent: false,
       },
+      {
+        source: "/en/build/smart-contracts/book/move-2.0",
+        destination: "/en/build/smart-contracts/book/move-2",
+        permanent: true,
+      },
     ],
   }),
 );


### PR DESCRIPTION
### Description
A redirect for old doc page to new one

Example: https://developer-docs-nextra-git-move-2-redirect-aptoslabs.vercel.app/en/build/smart-contracts/book/move-2.0

### Checklist

- Do all Lints pass?
  - [ ] Have you ran `pnpm spellcheck`?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
