### PR TITLE
Fix Terraform module source reference

### DIFF
--- a/apps/nextra/pages/en/network/nodes/validator-node/deploy-nodes/using-aws.mdx
+++ b/apps/nextra/pages/en/network/nodes/validator-node/deploy-nodes/using-aws.mdx
@@ -69,7 +69,7 @@ correct configurations (e.g., `source`, `image_tag` and `chain_id`).
 
     module "aptos-node" {
       # Download the Terraform module from the aptos-core repository.
-      source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/aws?ref=mainnet"
+      source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/aws"
       region        = <aws region>  # Specify the AWS region
       # zone_id     = "<Route53 zone id>"  # Use Route53 if you want to use DNS
       era           = 1  # Bump the era number to wipe the chain data

--- a/apps/nextra/pages/en/network/nodes/validator-node/deploy-nodes/using-azure.mdx
+++ b/apps/nextra/pages/en/network/nodes/validator-node/deploy-nodes/using-azure.mdx
@@ -69,7 +69,7 @@ correct configurations (e.g., `source`, `image_tag` and `chain_id`).
 
    module "aptos-node" {
      # Download the Terraform module from the aptos-core repository.
-     source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/azure?ref=mainnet"
+     source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/azure"
      region        = <azure region>  # Specify the Azure region
      era           = 1  # Bump the era number to wipe the chain data
      chain_id      = 1  # Use 1 for mainnet, or different values for other networks.

--- a/apps/nextra/pages/en/network/nodes/validator-node/deploy-nodes/using-gcp.mdx
+++ b/apps/nextra/pages/en/network/nodes/validator-node/deploy-nodes/using-gcp.mdx
@@ -66,7 +66,7 @@ account setup, and have created a new project for deploying your nodes.
 
    module "aptos-node" {
      # Download the Terraform module from the aptos-core repository.
-     source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/gcp?ref=mainnet"
+     source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/gcp"
      region        = "us-central1"  # Specify the GCP region
      zone          = "c"            # Specify the zone suffix
      project       = "<GCP Project ID>" # Specify your GCP project ID

--- a/apps/nextra/pages/zh/network/nodes/validator-node/deploy-nodes/using-aws.mdx
+++ b/apps/nextra/pages/zh/network/nodes/validator-node/deploy-nodes/using-aws.mdx
@@ -64,7 +64,7 @@ import { Callout, Steps } from 'nextra/components';
 
     module "aptos-node" {
       # 从aptos-core仓库下载Terraform模块。
-      source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/aws?ref=mainnet"
+      source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/aws"
       region        = <aws region>  # 指定AWS区域
       # zone_id     = "<Route53 zone id>"  # 如果您想使用DNS，请使用Route53
       era           = 1  # 提高时代编号以清除链数据

--- a/apps/nextra/pages/zh/network/nodes/validator-node/deploy-nodes/using-azure.mdx
+++ b/apps/nextra/pages/zh/network/nodes/validator-node/deploy-nodes/using-azure.mdx
@@ -63,7 +63,7 @@ import { Callout, Steps } from 'nextra/components';
 
    module "aptos-node" {
      # 从 aptos-core 仓库下载 Terraform 模块。
-     source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/azure?ref=mainnet"
+     source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/azure"
      region        = <azure region>  # 指定 Azure 区域
      era           = 1  # 提高时代编号以清除链数据
      chain_id      = 1  # 对于主网使用 1，或对于其他网络使用不同的值。

--- a/apps/nextra/pages/zh/network/nodes/validator-node/deploy-nodes/using-gcp.mdx
+++ b/apps/nextra/pages/zh/network/nodes/validator-node/deploy-nodes/using-gcp.mdx
@@ -62,7 +62,7 @@ import { Callout, Steps } from 'nextra/components';
 
    module "aptos-node" {
      # 从 aptos-core 仓库下载 Terraform 模块。
-     source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/gcp?ref=mainnet"
+     source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/gcp"
      region        = "us-central1"  # 指定 GCP 区域
      zone          = "c"            # 指定区域后缀
      project       = "<GCP Project ID>" # 指定您的 GCP 项目 ID


### PR DESCRIPTION
### Description

The `mainnet` branch is deprecated and Terraform configs should always be obtained from the `main` branch, which is the default.
