### PR TITLE
Fix broken links in Legacy TS SDK section

### DIFF
--- a/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk.mdx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk.mdx
@@ -7,5 +7,5 @@ import { Callout } from 'nextra/components';
 # Legacy TypeScript SDK
 
 <Callout emoji="🚨" type="error">
-  The Legacy TypeScript SDK package `aptos` is deprecated and will be replaced by the new TypeScript SDK. Please refer to the [new TypeScript SDK](/build/sdks/ts-sdk) for the latest features and updates.  Take a look at the [migration guide](legacy-ts-sdk/migration-guide.mdx).
+  The Legacy TypeScript SDK package `aptos` is deprecated and will be replaced by the new TypeScript SDK. Please refer to the [new TypeScript SDK](../ts-sdk.mdx) for the latest features and updates.  Take a look at the [migration guide](legacy-ts-sdk/migration-guide.mdx).
 </Callout>

--- a/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/migration-guide.mdx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/legacy-ts-sdk/migration-guide.mdx
@@ -5,7 +5,7 @@ title: "Migration Guide"
 import { Callout } from 'nextra/components';
 
 <Callout emoji="🚨" type="error">
-  The Legacy TypeScript SDK package `aptos` is deprecated and will be replaced by the new TypeScript SDK. Please refer to the [new TypeScript SDK](/build/sdks/ts-sdk) for the latest features and updates.
+  The Legacy TypeScript SDK package `aptos` is deprecated and will be replaced by the new TypeScript SDK. Please refer to the [new TypeScript SDK](../../ts-sdk.mdx) for the latest features and updates.
 </Callout>
 
 # TypeScript SDK Migration Guide


### PR DESCRIPTION
### Description

The warnings in the Legacy TS SDK had broken links to the new version. This fixes those 2 pages.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
