### PR TITLE
Update install-cli-windows.mdx

### DIFF
--- a/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
+++ b/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
@@ -13,7 +13,7 @@ For Windows, the easiest way to install the Aptos CLI tool is via Python script.
 ### In PowerShell, run the install script:
 
    ```powershell filename="Terminal"
-   Invoke-WebRequest -Uri "https://aptos.dev/scripts/install_cli.py" -OutFile "$env:TEMP\install_cli.py"; python3 "$env:TEMP\install_cli.py"
+   Invoke-WebRequest -Uri "https://aptos.dev/scripts/install_cli.py" -OutFile "$env:TEMP\install_cli.py"; python "$env:TEMP\install_cli.py"
    ```
 
    <Callout type="warning">


### PR DESCRIPTION
Changed the install script for windows where in "-OutFile python3" was creating python not found issue (when clearly python was installed) for installation in windows 11 (python ver. 3.13.0). Updated cmd to "-OutFile python "

### Description
![image](https://github.com/user-attachments/assets/78a08cab-b035-4e20-a48a-c2bac4c03c65)

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
