### PR TITLE
Add a link to enum compatibilty rules

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/book/package-upgrades.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/package-upgrades.mdx
@@ -85,6 +85,7 @@ published previously need to be compatible and follow the rules below:
   argument names can change.
 - `public(friend)` functions are treated as private and thus their signature can arbitrarily change. This is safe as
   only modules in the same package can call friend functions anyway, and they need to be updated if the signature changes.
+- [Enum type upgrade compatibility rules](enums.mdx#enum-type-upgrade-compatibility).
 
 When updating your modules, if you see an incompatible error, make sure to check the above rules and fix any violations.
 


### PR DESCRIPTION
### Description
Adding a link to enum type upgrade compatibility rules from where we list package upgrade rules.

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
