### PR TITLE
aptos-framework repo migration: developer docs [3/n]

### DIFF
--- a/apps/nextra/pages/en/build/cli/working-with-move-contracts/arguments-in-json-tutorial.mdx
+++ b/apps/nextra/pages/en/build/cli/working-with-move-contracts/arguments-in-json-tutorial.mdx
@@ -16,7 +16,7 @@ upgrade_policy = "compatible"
 test_account = "_"
 
 [dependencies]
-AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "mainnet", subdir = "aptos-move/framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 ```
 
 Here, the package is deployed under the named address `test_account`.
@@ -131,7 +131,7 @@ module test_account::cli_args {
       address_vec_vec: vector<vector<address>>,
       type_info_1: TypeInfo,
       type_info_2: TypeInfo,
-  } 
+  }
 ```
 
 A public entry function with multi-nested vectors can be used to set the fields:

--- a/apps/nextra/pages/en/build/guides/first-multisig.mdx
+++ b/apps/nextra/pages/en/build/guides/first-multisig.mdx
@@ -413,7 +413,7 @@ version = '1.0.0'
 upgrade_and_govern = '_'
 
 [dependencies]
-AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "mainnet", subdir = "aptos-move/framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 
 ```
 
@@ -617,7 +617,7 @@ version = '1.1.0'
 upgrade_and_govern = '_'
 
 [dependencies]
-AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "mainnet", subdir = "aptos-move/framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 ```
 
 ### Step 8.4: Upgrade the package

--- a/apps/nextra/pages/en/build/smart-contracts/book/packages.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/packages.mdx
@@ -68,7 +68,7 @@ authors* = [<string>]            # e.g., ["Joe Smith (joesmith@noemail.com)", "J
 [dependencies] # (Optional section) Paths to dependencies and instantiations or renamings of named addresses from each dependency
 # One or more lines declaring dependencies in the following format
 <string> = { local = <string>, addr_subst* = { (<string> = (<string> | "<hex_address>"))+ } } # local dependencies
-<string> = { git = <URL ending in .git>, subdir=<path to dir containing Move.toml inside git repo>, rev=<git commit hash>, addr_subst* = { (<string> = (<string> | "<hex_address>"))+ } } # git dependencies
+<string> = { git = <URL ending in .git>, subdir=<path to dir containing Move.toml inside git repo>, rev=<git commit hash or branch name>, addr_subst* = { (<string> = (<string> | "<hex_address>"))+ } } # git dependencies
 
 [dev-addresses] # (Optional section) Same as [addresses] section, but only included in "dev" and "test" modes
 # One or more lines declaring dev named addresses in the following format
@@ -105,7 +105,7 @@ specified_address = "0xB0B"
 # Local dependency
 LocalDep = { local = "projects/move-awesomeness", addr_subst = { "std" = "0x1" } }
 # Git dependency
-MoveStdlib = { git = "https://github.com/diem/diem.git", subdir="language/move-stdlib", rev = "56ab033cc403b489e891424a629e76f643d4fb6b" }
+MoveStdlib = { git = "https://github.com/aptos-labs/aptos-framework", subdir="move-stdlib", rev = "mainnet" }
 
 [dev-addresses] # For use when developing this module
 address_to_be_filled_in = "0x101010101"

--- a/apps/nextra/pages/en/build/smart-contracts/book/unit-testing.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/unit-testing.mdx
@@ -149,7 +149,7 @@ Next add the following to the `Move.toml`:
 
 ```toml
 [dependencies]
-MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir="aptos-move/framework/move-stdlib", rev = "main", addr_subst = { "std" = "0x1" } }
+MoveStdlib = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir="aptos-move/framework/move-stdlib", rev = "main", addr_subst = { "std" = "0x1" } }
 ```
 
 Next add the following module under the `sources` directory:

--- a/apps/nextra/pages/en/build/smart-contracts/create-package.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/create-package.mdx
@@ -61,9 +61,9 @@ version = "0.0.0"
 hello_blockchain = "_"
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "mainnet"
-subdir = "aptos-move/framework/aptos-framework"
+subdir = "aptos-framework"
 ```
 
 ### Add to `sources` directory

--- a/apps/nextra/pages/en/build/smart-contracts/scripts/compiling-scripts.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/scripts/compiling-scripts.mdx
@@ -49,7 +49,7 @@ hash for convenience
 
 ```bash filename="Terminal"
 Compiling, may take a little while to download git dependencies...
-UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
+UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-framework.git
 INCLUDING DEPENDENCY AptosFramework
 INCLUDING DEPENDENCY AptosStdlib
 INCLUDING DEPENDENCY MoveStdlib

--- a/apps/nextra/pages/en/build/smart-contracts/third-party-dependencies.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/third-party-dependencies.mdx
@@ -27,9 +27,9 @@ The default `Move.toml` includes `AptosFramework` as a git repository dependency
 
 ```toml filename="Move.toml"
   [dependencies.AptosFramework]
-  git = "<https://github.com/aptos-labs/aptos-core.git>"
+  git = "<https://github.com/aptos-labs/aptos-framework.git>"
   rev = "mainnet"
-  subdir = "aptos-move/framework/aptos-framework"
+  subdir = "aptos-framework"
 ```
 
 When Aptos CLI commands are ran, updates to the dependency are automatically retrieved and compiled against.
@@ -88,10 +88,10 @@ Reference it as a local source file after changing the file type to `{ModuleName
 
 ### Bytecode
 
-The Aptos CLI allows for downloading a [package's](book/packages.mdx) bytecode. 
+The Aptos CLI allows for downloading a [package's](book/packages.mdx) bytecode.
 
 ```bash filename="Terminal"
-aptos move download --account {account_addr} --bytecode --package {package_name} 
+aptos move download --account {account_addr} --bytecode --package {package_name}
 ```
 
 Each bytecode dependency requires their own package, with a structure of:

--- a/apps/nextra/pages/zh/build/cli/working-with-move-contracts/arguments-in-json-tutorial.mdx
+++ b/apps/nextra/pages/zh/build/cli/working-with-move-contracts/arguments-in-json-tutorial.mdx
@@ -20,7 +20,7 @@ upgrade_policy = "compatible"
 test_account = "_"
 
 [dependencies]
-AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "mainnet", subdir = "aptos-move/framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 ```
 
 这个包部署于名为 `test_account` 的地址。


### PR DESCRIPTION
This migrates the developer docs to use dependencies from the newly-setup aptos-framework repo.