### PR TITLE
[nextra]Object transfer instructions

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/deployment.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/deployment.mdx
@@ -67,7 +67,27 @@ Do you want to publish this package at object address 0x8d6eb306bcf6c61dbaa0dbf8
 
 Take note of the object address as you will need it later for upgrades.
 
-### Upgrade code in an existing package
+### Transfer and upgrade code in an existing package
+
+First, you may want to transfer the object from the deployer account to an admin account. The admin account will have rights to upgrade the code. 
+
+Here's how you can do it via CLI, here your `deployer_account` should be the current owner of the object. 
+```bash
+aptos move run —-function-id 0x1::object::transfer -—args address:<object_address> address:<new_owner_address> —-profile <deployer_account_profile>
+```
+
+Here's how you can do it via the typescript SDK:
+```typescript
+const transaction = await aptos.transaction.build.simple({
+  sender: deployerAccount.accountAddress,
+  data: {
+	  function: "0x1::object::transfer",
+      typeArguments: [`0x1::object::ObjectCore`],
+	  functionArguments: [object_address, new_owner_address],
+  },
+});
+```
+Now you can upgrade the code with the designated admin account, as shown below.
 
 If you wish to upgrade the code in the object deployed, run the following:
 - Replace `<named_address>` with the existing named address.
@@ -94,5 +114,6 @@ Do you want to upgrade the package 'MyPackage' at object address 0x8d6eb306bcf6c
 ```
 
 **Congrats, you have upgraded your code in the existing object!**
+
 
 </Steps>


### PR DESCRIPTION
### Description
It's common to use a deployer account and set upgradability permissions in the deployment script.

### Checklist
- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x ] Have you ran `pnpm lint`?
