### PR TITLE
Fix typos and grammar in documentation

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/book.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book.mdx
@@ -17,7 +17,7 @@ Move was designed and created as a secure, verified, yet flexible programming
 language. The first use of Move is for the implementation of the Diem
 blockchain, and it is currently being used on Aptos.
 
-This book is suitable for developers who are with some programming experience
+This book is suitable for developers with some programming experience
 and who want to begin understanding the core programming language and see
 examples of its usage.
 

--- a/apps/nextra/pages/en/developer-platforms/contribute/setup/migrating-from-docusaurus.mdx
+++ b/apps/nextra/pages/en/developer-platforms/contribute/setup/migrating-from-docusaurus.mdx
@@ -54,7 +54,7 @@ localStorage, such as `/en/docs/setup/...`.
 ## Codeblocks
 
 In docusaurus, [Codeblock](../components/codeblock.mdx) components are rendered differently 
-than in Nextra. When possible, try to add relevent `filename` information to help users understand
+than in Nextra. When possible, try to add relevant `filename` information to help users understand
 the context in which that code snippet is relevant.
 
 For example, if the docs ask the user to use the `CLI`, instead of doing


### PR DESCRIPTION
1. Fixed grammar in book.mdx:
- Changed: "developers who are with some programming experience"
- To: "developers with some programming experience"

2. Fixed typo in migrating-from-docusaurus.mdx:
- Changed: "relevent `filename`"
- To: "relevant `filename`"