### PR TITLE
Fix grammatical and syntax errors in Move documentation

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/book/bool.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/bool.mdx
@@ -28,6 +28,6 @@ Literals for `bool` are either `true` or `false`.
 
 ## Ownership
 
-As with the other scalar values built-in to the language, boolean values are implicitly copyable,
+As with the other scalar values built into the language, boolean values are implicitly copyable,
 meaning they can be copied without an explicit instruction such as
 [`copy`](variables.mdx#move-and-copy).

--- a/apps/nextra/pages/en/build/smart-contracts/book/enums.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/enums.mdx
@@ -85,7 +85,7 @@ The value of an enum value can be inspected using a match expression. For exampl
 fun area(self: &Shape): u64 {
     match (self) {
         Circle{radius}           => mul_with_pi(*radius * *radius),
-        Rectangle{width, height) => *width * *height
+        Rectangle{width, height} => *width * *height
     }
 }
 ```
@@ -227,7 +227,7 @@ enum VersionedData has key {
 }
 ```
 
-That following upgrade would not be allowed, since the order of variants must be preserved:
+The following upgrade would not be allowed, since the order of variants must be preserved:
 
 ```move
 enum VersionedData has key {


### PR DESCRIPTION
Changes made:
1. Fixed "built-to" to "built into" in bool.mdx documentation
2. Fixed syntax error in enums.mdx - corrected closing bracket in Rectangle pattern matching
3. Changed "That following" to "The following" in enum upgrade description
4. Fixed formatting and syntax in code examples

These changes improve readability and correctness of the Move language documentation.