### PR TITLE
Insert access control check for pause/unpause functionality inside the move sec. guidelines

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/move-security-guidelines.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/move-security-guidelines.mdx
@@ -694,11 +694,13 @@ module 0x42::example {
   }
 
   public entry fun pause_protocol(admin: &signer) {
+    assert!(signer::address_of(admin)==@protocol_address, ERR_NOT_ADMIN);
     let state = borrow_global_mut<State>(@protocol_address);
     state.is_paused = true;
   }
 
   public entry fun resume_protocol(admin: &signer) {
+    assert!(signer::address_of(admin)==@protocol_address, ERR_NOT_ADMIN);
     let state = borrow_global_mut<State>(@protocol_address);
     state.is_paused = false;
   }


### PR DESCRIPTION
Insert access control check for pause/unpause functionality inside the move sec. guidelines

### Description

### Checklist

- Do all Lints pass?
  - [ ] Have you ran `pnpm spellcheck`?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
