### PR TITLE
Fix typos and improve grammar in `resources.mdx`, `validator-node.mdx`, and `validator-node.md`

### DIFF
--- a/apps/nextra/pages/en/network/blockchain/resources.mdx
+++ b/apps/nextra/pages/en/network/blockchain/resources.mdx
@@ -5,7 +5,7 @@ id: "resources"
 
 # Resources
 
-On Aptos, on-chain state is organized into resources and modules. These are then stored within the individual accounts. This is different from other blockchains, such as Ethereum, where each smart contract  maintains its own storage space. See [Accounts](accounts.mdx) for more details on accounts.
+On Aptos, on-chain state is organized into resources and modules. These are then stored within the individual accounts. This is different from other blockchains, such as Ethereum, where each smart contract maintains its own storage space. See [Accounts](accounts.mdx) for more details on accounts.
 
 ## Resources vs Instances
 

--- a/apps/nextra/pages/en/network/blockchain/resources.mdx
+++ b/apps/nextra/pages/en/network/blockchain/resources.mdx
@@ -5,7 +5,7 @@ id: "resources"
 
 # Resources
 
-On Aptos, on-chain state is organized into resources and modules. These are then stored within the individual accounts. This is different from other blockchains, such as Ethereum, where each smart contract maintains their own storage space. See [Accounts](accounts.mdx) for more details on accounts.
+On Aptos, on-chain state is organized into resources and modules. These are then stored within the individual accounts. This is different from other blockchains, such as Ethereum, where each smart contract  maintains its own storage space. See [Accounts](accounts.mdx) for more details on accounts.
 
 ## Resources vs Instances
 
@@ -57,7 +57,7 @@ Ownership, on the other hand, is signified by either storing a resource under an
 
 ## Viewing a resource
 
-Resources are stored within accounts. Resources can be located by searching within the owner's account for the resource at its full query path inclusive of the account where it is stored as well as its address and module. Resources can be viewed on the [Aptos Explorer](https://explorer.aptoslabs.com/) by searching for the owning account or be directly fetched from a fullnode's API.
+Resources are stored within accounts. Resources can be located by searching within the owner's account for the resource at its full query path inclusive of the account where it is stored as well as its address and module. Resources can be viewed on the [Aptos Explorer](https://explorer.aptoslabs.com/) by searching for the owning account or directly fetched from a fullnode's API.
 
 ## How resources are stored
 

--- a/apps/nextra/pages/en/network/nodes/validator-node.mdx
+++ b/apps/nextra/pages/en/network/nodes/validator-node.mdx
@@ -51,7 +51,7 @@ These will give your nodes the information they need to start syncing with other
 Initialize the staking pool, join the validator set and start validating to earn rewards.
 Before other peers will accept connections from your nodes, you will need to join the validator set.
 To do this, you must initialize a staking pool and delegate to operators and voters.
-Once your staking pool has been setup, you can join the validator set.
+Once your staking pool has been set up, you can join the validator set.
 At this point your nodes will begin to sync with the network and your validator will be able to start participating in consensus.
 This is when you can start earning rewards.
 

--- a/apps/nextra/pages/zh/network/nodes/validator-node.mdx
+++ b/apps/nextra/pages/zh/network/nodes/validator-node.mdx
@@ -1,5 +1,5 @@
 ---
-title: "运行验证者节点（Valdator）和验证者全节点(VFN)"
+title: "运行验证者节点（Validator）和验证者全节点(VFN)"
 ---
 
 import { Callout, Steps } from "nextra/components";


### PR DESCRIPTION
### Description

This pull request includes fixes and updates for three files: `resources.mdx`, `validator-node.mdx`, and `validator-node.md`. Below are the changes made:

1. **`resources.mdx`**:
   - Fixed grammar: changed **"their own storage space"** to **"its own storage space"** for consistency with singular subject agreement.
   - Improved clarity and consistency in descriptions of resource storage and API references.

2. **`validator-node.mdx`**:
   - Corrected grammar: updated **"has been setup"** to **"has been set up"** for proper verb usage.

3. **`validator-node.md`**:
   - Fixed a typo: corrected **"Valdiator"** to **"Validator"** in the Chinese title.

These changes ensure improved accuracy and clarity in documentation.
