### PR TITLE
[Move reference] show correct module in dropdown on page load

### DIFF
--- a/apps/nextra/components/move-reference/ModuleContainer.tsx
+++ b/apps/nextra/components/move-reference/ModuleContainer.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Select, { ActionMeta, SingleValue } from "react-select";
 import { Framework, GITHUB_APTOS_CORE, PKGS } from "./shared";
 import { useMoveReference } from "./MoveReferenceProvider";
@@ -166,13 +166,16 @@ interface ModuleSelectProps {
 
 export function ModuleSelect({ branch }: ModuleSelectProps) {
   const groupedOptions = useFrameworksData(branch);
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
-  const { updatePage } = useMoveReference();
+  const { updatePage, page } = useMoveReference();
 
-  const handleChange = (
-    newValue: SingleValue<PackageOption>,
-    actionMeta: ActionMeta<PackageOption>,
-  ) => {
+  // Controlled value of the select is derived from `page`
+  const value = !page
+    ? null
+    : groupedOptions.reduce((found, group) => {
+        return found || group.options.find((opt) => opt.value === page) || null;
+      }, null);
+
+  const handleChange = (newValue: SingleValue<PackageOption>) => {
     if (newValue?.value) {
       updatePage(newValue.value as Branch);
     }
@@ -181,9 +184,9 @@ export function ModuleSelect({ branch }: ModuleSelectProps) {
   return (
     <Select<PackageOption, false, GroupedOption>
       inputId="basic-grouped-id"
-      defaultValue={packageOptions[0]}
       options={groupedOptions}
       formatGroupLabel={FormatGroupLabel}
+      value={value}
       onChange={handleChange}
       classNames={{
         container: () => "lg:max-w-[calc(100%-16rem)]",


### PR DESCRIPTION
### Description
When opening the move reference page on a specific module (e.g. https://aptos.dev/en/build/smart-contracts/move-reference?page=move-stdlib%2Fdoc%2Fstring.md), the dropdown will always show the default value (but will correctly update when a user makes a selection).

This change ensures that the correct value is displayed at all times.

**Wrong value in dropdown**
<img width="596" alt="image" src="https://github.com/user-attachments/assets/ac776d08-881d-40e3-8b26-2ee46e5c493c">



### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm spellcheck`?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
