### PR TITLE
Faucet page error handling and locale redirect

### DIFF
--- a/apps/nextra/components/faucet/FaucetForm.tsx
+++ b/apps/nextra/components/faucet/FaucetForm.tsx
@@ -60,7 +60,7 @@ export function FaucetForm() {
         } else if (data.message) {
           setError(data.message);
         } else {
-          setError(`Unknown error: ${e}`);
+          setError(`Unknown error: ${JSON.stringify(data)}`);
         }
       }
     } catch (e) {

--- a/apps/nextra/components/faucet/FaucetForm.tsx
+++ b/apps/nextra/components/faucet/FaucetForm.tsx
@@ -51,16 +51,16 @@ export function FaucetForm() {
       } else {
         const text = await response.text();
         const data: any = JSON.parse(text);
-        if (typeof data === "string") {
-          setError(data);
-        } else if (data.message) {
-          setError(data.message);
-        } else {
+        if (data.rejection_reasons && data.rejection_reasons.length > 0) {
           setError(
             data["rejection_reasons"]
               .map((reason: any) => reason.reason)
               .join(", "),
           );
+        } else if (data.message) {
+          setError(data.message);
+        } else {
+          setError(`Unknown error: ${e}`);
         }
       }
     } catch (e) {

--- a/apps/nextra/middleware.ts
+++ b/apps/nextra/middleware.ts
@@ -1,30 +1,7 @@
 import { NextResponse, NextRequest } from "next/server";
-import { i18nConfig } from "@docs-config";
 
 // Routes in this list will be redirected to a prefixed route
 const NON_LOCALE_ROUTES = ["/network/faucet"];
-
-function getCookie(cookies, key) {
-  if (typeof cookies.get === "function") {
-    const cookie = cookies.get(key);
-    if (cookie && typeof cookie === "object") {
-      return cookie.value;
-    }
-    return cookie;
-  }
-  return cookies[key];
-}
-
-function getLocaleFromHeader(headerValue: string | null) {
-  const allowedLocales = Object.keys(i18nConfig);
-  const possibleLocales = (headerValue || "")
-    .split(/[;,]/)
-    .map((s) => s.trim())
-    .map((s) => s.split("-")[0]);
-  return (
-    possibleLocales.find((locale) => allowedLocales.includes(locale)) || null
-  );
-}
 
 export function middleware(request: NextRequest) {
   const { nextUrl } = request;
@@ -33,27 +10,8 @@ export function middleware(request: NextRequest) {
     return;
   }
 
-  let locale: string | null = null;
-  // If there is a locale cookie, we try to use it.
-  try {
-    locale = getCookie(request.cookies, "NEXT_LOCALE");
-  } catch {
-    // The locale from the cookie isn't valid.
-    // https://github.com/vercel/next.js/blob/e5dee17f776dcc79ebb269f7b7341fa6e2b6c3f1/packages/next/server/web/next-url.ts#L122-L129
-  }
-
-  // Otherwise, try to figure it out via the `accept-languages` header.
-  if (!locale) {
-    const headerLocale = getLocaleFromHeader(
-      request.headers.get("accept-language"),
-    );
-    locale = headerLocale ?? "en";
-  }
-
+  // for now, the custom pages are only available in en, no need to determine a locale
   return NextResponse.redirect(
-    new URL(
-      `/${locale || "en"}${nextUrl.pathname}${nextUrl.search}`,
-      request.url,
-    ),
+    new URL(`/en${nextUrl.pathname}${nextUrl.search}`, request.url),
   );
 }


### PR DESCRIPTION
### Description

Updates:
* hardcodes redirect from `/network/faucet/` to `/en/network/faucet/` (instead of auto-detecing locale) as page is only available in english (other locales will throw a 404)
* fixed error handling

### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
