### PR TITLE
Remove github from faucet login for now

### DIFF
--- a/apps/nextra/components/faucet/index.tsx
+++ b/apps/nextra/components/faucet/index.tsx
@@ -6,7 +6,11 @@ import { LoginButton } from "@components/login-button";
 import { IconGithub, IconGoogle } from "@components/landing/components/Icons";
 import { FaucetForm } from "@components/faucet/FaucetForm";
 
-export function Faucet() {
+export interface FaucetProps {
+  showGithub?: boolean;
+}
+
+export function Faucet({ showGithub = false }: FaucetProps) {
   const { error, user, handleGithubLogin, handleGoogleLogin, handleLogout } =
     useAuth();
 
@@ -41,11 +45,13 @@ export function Faucet() {
               provider="Google"
               icon={<IconGoogle style={{ width: "16", height: "16" }} />}
             />
-            <LoginButton
-              handleLogin={handleGithubLogin}
-              provider="GitHub"
-              icon={<IconGithub />}
-            />
+            {showGithub && (
+              <LoginButton
+                handleLogin={handleGithubLogin}
+                provider="GitHub"
+                icon={<IconGithub />}
+              />
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
### Description

Remove the github login option from the faucet until we figure out why it breaks

### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [x] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [x] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
