### PR TITLE
fix: Include type arguments for object transfer in cli example

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/deployment.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/deployment.mdx
@@ -73,7 +73,7 @@ First, you may want to transfer the object from the deployer account to an admin
 
 Here's how you can do it via CLI, here your `deployer_account` should be the current owner of the object. 
 ```bash
-aptos move run —-function-id 0x1::object::transfer -—args address:<object_address> address:<new_owner_address> —-profile <deployer_account_profile>
+aptos move run —-function-id 0x1::object::transfer --type-args 0x1::object::ObjectCore -—args address:<object_address> address:<new_owner_address> —-profile <deployer_account_profile>
 ```
 
 Here's how you can do it via the typescript SDK:


### PR DESCRIPTION
### Description

### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [X] Have you ran `pnpm fmt`?
  - [X] Have you ran `pnpm lint`?
