### PR TITLE
fix: add type-args when transferring code object

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/deployment.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/deployment.mdx
@@ -73,7 +73,7 @@ First, you may want to transfer the object from the deployer account to an admin
 
 Here's how you can do it via CLI, here your `deployer_account` should be the current owner of the object. 
 ```bash
-aptos move run —-function-id 0x1::object::transfer -—args address:<object_address> address:<new_owner_address> —-profile <deployer_account_profile>
+aptos move run —-function-id 0x1::object::transfer --type-args "0x1::object::ObjectCore" -—args address:<object_address> address:<new_owner_address> —-profile <deployer_account_profile>
 ```
 
 Here's how you can do it via the typescript SDK:


### PR DESCRIPTION
### Description

Current command does not work as `0x1::object::transfer` requires a type arg

### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [x] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [x] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
