### PR TITLE
Add beneficiary to delegation pool entities

### DIFF
--- a/apps/nextra/pages/en/network/blockchain/delegated-staking.mdx
+++ b/apps/nextra/pages/en/network/blockchain/delegated-staking.mdx
@@ -2,20 +2,23 @@
 title: "Delegated Staking"
 ---
 
-import { Callout } from 'nextra/components';
+import { Callout } from "nextra/components";
 
 # Delegated Staking
 
 ## Delegated Staking on the Aptos Blockchain
 
 <Callout type="info">
-We strongly recommend that you read about [Staking](staking.mdx) first.
+  We strongly recommend that you read about [Staking](staking.mdx) first.
 </Callout>
 
 Delegated staking is an extension of the staking protocol. A delegation pool abstracts the stake owner to an entity capable of collecting stake from delegators and adding it on their behalf to the native stake pool attached to the validator. This allows multiple entities to form a stake pool that achieves the minimum requirements for the validator to join the validator set. While delegators can add stake to an inactive pool, the delegation pool will not earn rewards until it is active.
 
 <Callout type="warning">
-Delegation pools are permissionless and anyone can add stake. Delegation pools cannot be changed to stake pools once it's created or vice versa, though it can be removed from the validator set and assets withdrawn. For full details of the stake pool, see [Staking](staking.mdx)
+  Delegation pools are permissionless and anyone can add stake. Delegation pools
+  cannot be changed to stake pools once it's created or vice versa, though it
+  can be removed from the validator set and assets withdrawn. For full details
+  of the stake pool, see [Staking](staking.mdx)
 </Callout>
 
 For the full delegation pool smart contract, see [delegation_pool.move](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/delegation_pool.move)
@@ -26,12 +29,13 @@ See full list of [Delegation Pool Operations](../nodes/validator-node/connect-no
 
 ![image](https://user-images.githubusercontent.com/120680608/234953723-ae6cc89e-76d8-4014-89f3-ec8799c7b281.png)
 
-There are four entity types:
+There are five entity types:
 
 - Owner
 - Operator
 - Voter
 - Delegator
+- Beneficiary
 
 Using this model, the owner does not have to stake on the Aptos blockchain in order to run a validator.
 
@@ -61,7 +65,8 @@ The operator receives commission that is distributed automatically at the end of
 An owner can designate a voter. This enables the voter to participate in governance. The voter will use the voter key to sign the governance votes in the transactions.
 
 <Callout type="info">
-This document describes staking. See [Governance](governance.mdx) for how to participate in the Aptos on-chain governance using the owner-voter model.
+  This document describes staking. See [Governance](governance.mdx) for how to
+  participate in the Aptos on-chain governance using the owner-voter model.
 </Callout>
 
 ### Delegator
@@ -73,10 +78,21 @@ A delegator is anyone who has stake in the delegation pool. Delegators earn rewa
 3. Reactivate stake
 4. Withdraw stake
 
+### Beneficiary
+
+A beneficiary is an address designated by the operator to receive operator commission rewards. Key aspects of the beneficiary role:
+
+1. Each operator can set only one beneficiary address across all their delegation pools
+2. The beneficiary can perform operations like unlock and withdraw for earned commission
+3. When changing beneficiaries, any unpaid commission rewards will go to the new beneficiary
+4. The operator can set or change the beneficiary using the `set_beneficiary_for_operator` function
+
 ## Validator flow
 
 <Callout type="info">
-See [Delegation pool operations](../nodes/validator-node/connect-nodes/delegation-pool-operations.mdx) for the correct sequence of commands to run for the below flow.
+  See [Delegation pool
+  operations](../nodes/validator-node/connect-nodes/delegation-pool-operations.mdx)
+  for the correct sequence of commands to run for the below flow.
 </Callout>
 
 1. [Operator deploys validator node](../nodes/validator-node.mdx)
@@ -102,7 +118,9 @@ Participating as a delegation validator node on the Aptos network works like thi
 6. Operator must wait until the new epoch starts before their validator becomes active.
 
 <Callout type="info">
-For step-by-step instructions on how to join the validator set, see: [Joining Validator Set](../nodes/validator-node/connect-nodes/staking-pool-operations.mdx#joining-validator-set).
+  For step-by-step instructions on how to join the validator set, see: [Joining
+  Validator
+  Set](../nodes/validator-node/connect-nodes/staking-pool-operations.mdx#joining-validator-set).
 </Callout>
 
 ### Automatic lockup duration


### PR DESCRIPTION
### Description

Added Beneficiary entity to `delegated-staking.mdx` defining it as the operator-designated address for receiving commission rewards.

This addition is crucial for completeness and accuracy as Beneficiaries play a vital role in commission distribution within the delegation system. Without this documentation, operators and stakeholders lack clarity on how operator commissions are managed and distributed.

### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
