### PR TITLE
Update digital-asset.mdx

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/digital-asset.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/digital-asset.mdx
@@ -382,7 +382,7 @@ The main drawback of using the `aptos_token` module is that the Tokens are not e
 
 ### Minting with `aptos_token`
 
-Minting a `Token` using `aptos_token` requires the same parameters as any token that implements the DA standard. In addition though, the `aptos_token` module allows you to specificy a property map of key/value pairs for any other properties your specific NFT may require.
+Minting a `Token` using `aptos_token` requires the same parameters as any token that implements the DA standard. In addition though, the `aptos_token` module allows you to specify a property map of key/value pairs for any other properties your specific NFT may require.
 
 You can mint your `Token` by calling `aptos_token::mint` like so:
 


### PR DESCRIPTION
Update with minor typo fix

### Description

At the [Aptos Digital Asset (DA) Standard](https://aptos.dev/en/build/smart-contracts/digital-asset) page there is minor typo.
Changed the typo from **"specificy "** to **"specify"**

![image](https://github.com/user-attachments/assets/b5923cde-20c1-4fbf-ab03-2f7e6de4fd8a)
