### PR TITLE
Add note about the acquires annotation bug fix

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/book/move-2.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/move-2.mdx
@@ -35,3 +35,5 @@ The Move 2.0 language release adds the following features to Move:
 - **Well-defined evaluation order** The evaluation order in the cases below is now well-defined (these were previously unspecified):
     - The (a) arguments to a function call, and the (b) operand expressions in a binary operation, are both evaluated from left-to-right.
     - Given a "mutate" expression (see [mutating through a reference](variables.mdx#mutating-through-a-reference)) of the form `*lexp = rexp`, where `lexp` is an expression of type `&mut T` and `rexp` is an expression of type `T`, `rexp` is evaluated first, followed by `lexp`.
+
+- **Bug fix for acquires annotation** [A function should be annotated with `acquires`](functions.mdx#acquires) if and only if it accesses a resource using `move_from`, `borrow_global`, or `borrow_global_mut`, either directly or transitively through a call. Otherwise, it is an error. Previously, when the transitive call graph included a cycle, such errors were not reported: this was incorrect behavior. We have now corrected this behavior to report these errors even when the transitive call graph has cycles.


### PR DESCRIPTION
### Description

In Move 2, we report an error for unnecessary `acquires` even when the transitive call graph has a cycle (bug fix). We add this info to the release notes.

### Checklist
- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
