### PR TITLE
[Nodes] Add configuration guide for consensus observer

### DIFF
--- a/apps/nextra/pages/en/network/nodes/configure.mdx
+++ b/apps/nextra/pages/en/network/nodes/configure.mdx
@@ -6,6 +6,7 @@ title: "Configure a Node"
 
 This section contains tutorials for understanding and configuring Aptos node internals. These include:
 
+- ### [Consensus Observer](configure/consensus-observer.mdx)
 - ### [State Synchronization](configure/state-sync.mdx)
 - ### [Data Pruning](configure/data-pruning.mdx)
 - ### [Telemetry](configure/telemetry.mdx)

--- a/apps/nextra/pages/en/network/nodes/configure/_meta.tsx
+++ b/apps/nextra/pages/en/network/nodes/configure/_meta.tsx
@@ -1,4 +1,5 @@
 export default {
+  "consensus-observer": "Consensus Observer",
   "state-sync": "State Synchronization",
   "data-pruning": "Data Pruning",
   telemetry: "Telemetry",

--- a/apps/nextra/pages/en/network/nodes/configure/consensus-observer.mdx
+++ b/apps/nextra/pages/en/network/nodes/configure/consensus-observer.mdx
@@ -1,0 +1,57 @@
+---
+title: "Consensus Observer"
+---
+
+import { Callout, Steps } from 'nextra/components';
+
+# Consensus Observer
+
+<Callout type="warning">
+**Public Fullnodes (PFNs)**<br />
+The configuration settings described in this document are for public fullnodes (PFNs) only.
+Consensus observer has already been enabled (by default) for validators and validator fullnodes (VFNs).
+It is not recommended to change the consensus observer configurations for validators and VFNs.
+</Callout>
+
+Consensus observer is a new data dissemination technique that reduces block synchronization time, and
+transaction latencies for Aptos fullnodes (i.e., VFNs and PFNs). It has been shown to reduce end-to-end
+transaction latencies in Mainnet by 10% to 50%, depending on the load (i.e., transactions per second).
+
+More information on consensus observer can be found in the AIP: [AIP-93: Consensus Observer](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-93.md).
+
+## Configure consensus observer
+
+<Callout type="warning" emoji="❗">
+**Minimum Hardware Requirements**<br />
+Consensus observer is not enabled on PFNs (by default) because it requires nodes to meet the
+[minimum hardware requirements](../full-node/pfn-requirements#hardware-requirements).
+If your node is under-provisioned and does not meet these requirements, enabling consensus observer
+will result in degraded performance because it requires more CPU than traditional state sync. Only
+enable consensus observer if your node meets the minimum hardware requirements.
+</Callout>
+
+### Enable consensus observer
+
+To enable consensus observer on your PFN, add the following to your node configuration file (e.g., `fullnode.yaml`):
+
+```yaml filename="fullnode.yaml"
+consensus:
+  enable_pre_commit: false
+
+consensus_observer:
+  observer_enabled: true
+  publisher_enabled: true
+```
+
+### Disable consensus observer
+
+To disable consensus observer on your PFN, add the following to your node configuration file (e.g., `fullnode.yaml`):
+
+```yaml filename="fullnode.yaml"
+consensus:
+  enable_pre_commit: true
+
+consensus_observer:
+  observer_enabled: false
+  publisher_enabled: false
+```


### PR DESCRIPTION
### Description
This PR adds a new configuration page for consensus observer in the node section. You can see a preview [here](https://developer-docs-nextra-git-codetails-aptoslabs.vercel.app/en/network/nodes/configure/consensus-observer).

### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
