### PR TITLE
Fix link to std library and update compiler v2 statement

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts.mdx
@@ -79,4 +79,4 @@ Here is a `hello_blockchain` example of move
 - [Pontem Move Playground](https://playground.pontem.network/)
 - [Collection of nestable Move resources](https://github.com/taoheorg/taohe)
 
-A new Move compiler and language version is currently in early beta testing. If you are interested to play with it, check [this page](smart-contracts/compiler_v2.mdx).
+We have a new Move on Aptos compiler that supports Move 2. See [this page](smart-contracts/compiler_v2.mdx) for more information.

--- a/apps/nextra/pages/en/build/smart-contracts/book/standard-library.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/standard-library.mdx
@@ -1,4 +1,4 @@
 # Libraries
 
 Aptos provides multiple useful libraries for developers. The complete up-to-date
-docs can be found [here](../../../network/blockchain/move.mdx).
+docs can be found [here](../move-reference).


### PR DESCRIPTION
### Description

1. Update link to std library documentation (to point to the correct page)
2. Update text about compiler v2 (no longer in early beta testing)
3. `pnpm fmt` or `pnpm lint` created changes for `mdast.test.ts`

### Checklist

- Do all Lints pass?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
