### PR TITLE
[lychee] Fix broken link for aptosconnect

### DIFF
--- a/apps/nextra/pages/en/build/sdks/wallet-adapter.mdx
+++ b/apps/nextra/pages/en/build/sdks/wallet-adapter.mdx
@@ -19,7 +19,7 @@ Follow the [Wallet Adapter for Dapp Builders Guide](./wallet-adapter/dapp.mdx) o
 Follow one of these guides for how to implement a Wallet Adapter plugin that dapps can connect to:
 
 1. For [Browser Extension Wallets](./wallet-adapter/browser-extension-wallets.mdx) (ex. [Petra](https://chromewebstore.google.com/detail/petra-aptos-wallet/ejjladinnckdgjemekebdpeokbikhfci?hl=en))
-2. For [SDK Wallets](./wallet-adapter/wallets.mdx) (ex. [AptosConnect](https://aptosconnect.app/dashboard/main-account/tokens/))
+2. For [SDK Wallets](./wallet-adapter/wallets.mdx) (ex. [AptosConnect](https://aptosconnect.app))
 
 ## Reference Material
 


### PR DESCRIPTION
### Description

### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
