### PR TITLE
Update GCP step typo

### DIFF
--- a/apps/nextra/pages/en/network/nodes/validator-node/deploy-nodes/using-gcp.mdx
+++ b/apps/nextra/pages/en/network/nodes/validator-node/deploy-nodes/using-gcp.mdx
@@ -223,4 +223,4 @@ to the Aptos network just yet.
 
 ## Connecting to the Aptos Network
 
-You have now completed setting up your validator and VFN using AWS. Proceed to [Connect Nodes](../connect-nodes.mdx) for the next steps.
+You have now completed setting up your validator and VFN using GCP. Proceed to [Connect Nodes](../connect-nodes.mdx) for the next steps.


### PR DESCRIPTION
### Description

Updates a mistaken "AWS" to "GCP".

I also verified that the steps match the other set of working steps 1:1. https://github.com/aptos-labs/aptos-core/blob/main/terraform/aptos-node/gcp/README.md

### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [X] Have you ran `pnpm fmt`?
  - [X] Have you ran `pnpm lint`?
