### PR TITLE
[AA] Fix parameter type error in the documentation

### DIFF
--- a/apps/nextra/pages/en/build/sdks/ts-sdk/account/account-abstraction.mdx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/account/account-abstraction.mdx
@@ -260,7 +260,7 @@ const pendingCoinTransferTransaction = aptos.transaction.signAndSubmitTransactio
   signer: abstractedAccount,
 });
 
-await aptos.waitForTransaction({ hash: pendingCoinTransferTransaction.hash });
+await aptos.waitForTransaction({ transactionHash: pendingCoinTransferTransaction.hash });
 
 console.log("Coin transfer transaction submitted! ", pendingCoinTransferTransaction.hash);
 ```

--- a/apps/nextra/pages/en/build/sdks/ts-sdk/account/account-abstraction.mdx
+++ b/apps/nextra/pages/en/build/sdks/ts-sdk/account/account-abstraction.mdx
@@ -246,7 +246,7 @@ Once you have created the abstracted account, you can use it to sign transaction
 is the same as the abstracted account's address.
 
 ```ts
-const coinTransferTransaction = new aptos.transaction.build.simple({
+const coinTransferTransaction = await aptos.transaction.build.simple({
   sender: abstractedAccount.accountAddress,
   data: {
     function: "0x1::coin::transfer",
@@ -255,7 +255,7 @@ const coinTransferTransaction = new aptos.transaction.build.simple({
   },
 });
 
-const pendingCoinTransferTransaction = aptos.transaction.signAndSubmitTransaction({
+const pendingCoinTransferTransaction = await aptos.transaction.signAndSubmitTransaction({
   transaction: coinTransferTransaction,
   signer: abstractedAccount,
 });


### PR DESCRIPTION
### Description

https://github.com/aptos-labs/aptos-ts-sdk/blob/85cfc416c5abdea312106562e21448719a52062b/src/api/transaction.ts#L351

```
  async waitForTransaction(args: {
    transactionHash: HexInput;
    options?: WaitForTransactionOptions;
  }): Promise<CommittedTransactionResponse> {
    return waitForTransaction({
      aptosConfig: this.config,
      ...args,
    });
  }
```
### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [x] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [x] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
