### PR TITLE
Fix broken link and update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 We now use [lychee-broken-link-checker](https://github.com/marketplace/actions/lychee-broken-link-checker) to check for broken links in the GitHub Markdown. We use a corresponding link checker for pages on Aptos.dev.
 
 With results visible at:
-https://github.com//aptos-labs/developer-docs/actions/workflows/links.yml
+[https://github.com/aptos-labs/developer-docs/actions/workflows/links.yml](https://github.com/aptos-labs/developer-docs/actions/workflows/links.yml)
 
 ## Installation
 
@@ -33,7 +33,7 @@ brew install node
 - Install the latest [pnpm](https://pnpm.io/installation) by executing the below command on your Terminal:
 
 ```sh
-curl -fsSL https://get.pnpm.io/install.sh | sh -
+curl -fsSL https://get.pnpm.io/install.sh | sh - 
 ```
 
 ## Clone the Developer docs repo
@@ -44,11 +44,13 @@ git clone https://github.com/aptos-labs/developer-docs.git
 
 ## Install deps
 
-You may have to run the following command first if you are on macOS M1 Sonoma or newer
+You may have to run the following command first if you are on macOS M1 Sonoma or newer:
 
 ```sh
 pnpm add node-gyp -g
 ```
+
+Then, run:
 
 ```sh
 pnpm install
@@ -58,17 +60,17 @@ pnpm install
 
 > Note: PLEASE SEE `apps/nextra/README.md` for more details!
 
-0. Setup environment
+1. Setup environment
 
 Ensure you have configured your `.env` properly under `apps/nextra/.env`. There is a `.env.example` there that you can duplicate and rename to `.env` for simplicity.
 
-To ensure you have the right setup, you can run
+To ensure you have the right setup, you can run:
 
 ```sh
 pnpm prebuild
 ```
 
-1. Build Nextra
+2. Build Nextra
 
 ```bash
 npx turbo run build --filter={apps/nextra}...
@@ -76,13 +78,13 @@ npx turbo run build --filter={apps/nextra}...
 
 This will build `apps/nextra` and all local packages it depends on.
 
-2. Navigate to the correct subdirectory
+3. Navigate to the correct subdirectory
 
 ```sh
 cd apps/nextra
 ```
 
-3. Run the development server
+4. Run the development server
 
 ```sh
 pnpm dev
@@ -98,9 +100,9 @@ pnpm fmt
 
 ## Regenerating contributors
 
-The src/contributors.json file (which powers the list of Authors at the bottom of doc pages) needs to be manually generated.
+The `src/contributors.json` file (which powers the list of Authors at the bottom of doc pages) needs to be manually generated.
 
-In order to generate the contributor map you must authenticate with GitHub. The best way to do that is using GitHub CLI [installation guide](https://github.com/cli/cli#installation). Once you have the GitHub CLI installed, you can run the following command to authenticate:
+In order to generate the contributor map, you must authenticate with GitHub. The best way to do that is using GitHub CLI [installation guide](https://github.com/cli/cli#installation). Once you have the GitHub CLI installed, you can run the following command to authenticate:
 
 ```sh
 gh auth login --scopes read:user,user:email

--- a/apps/nextra/components/landing/sections/FooterSection.tsx
+++ b/apps/nextra/components/landing/sections/FooterSection.tsx
@@ -55,7 +55,7 @@ export function FooterSection() {
             <Link href="https://t.me/aptos" title={t.telegramAlt}>
               <IconTelegram />
             </Link>
-            <Link href="https://twitter.com/Aptos" title={t.twitterAlt}>
+            <Link href="https://x.com/Aptos" title={t.twitterAlt}>
               <IconTwitter />
             </Link>
           </div>

--- a/apps/nextra/pages/en/developer-platforms/contribute/examples/pairings.mdx
+++ b/apps/nextra/pages/en/developer-platforms/contribute/examples/pairings.mdx
@@ -28,7 +28,7 @@ In fact, by the end of this post, [some of you might want to spend a year or two
 </Callout>
 
 <Callout type="warning">
-**Twitter correction:** The [original tweet announcing this blog post](https://twitter.com/alinush407/status/1612518576862408705) stated that _"**S**NARKs would not be possible without [pairings]"_, with the highlighted **S** meant to emphasize the "succinctness" of such SNARKs. However, [thanks to several folks on Twitter](#acknowledgements), I realized this is **not** exactly true and depends on what one means by "succinct." Specifically, "succinct" SNARKs, in the _polylogarithmic proof size_ sense defined by Gentry and Wichs[^GW10], exist from a plethora of assumptions, including discrete log[^BCCplus16] or random oracles[^Mica98]. Furthermore, "succinct" SNARKs, in the sense of $O(1)$ group elements proof size, exist from RSA assumptions too[^LM18]. What pairings do give us, currently, are SNARKs with the smallest, concrete proof sizes (i.e., in # of bytes).
+**Twitter correction:** The [original tweet announcing this blog post](https://x.com/alinush407/status/1612518576862408705) stated that _"**S**NARKs would not be possible without [pairings]"_, with the highlighted **S** meant to emphasize the "succinctness" of such SNARKs. However, [thanks to several folks on Twitter](#acknowledgements), I realized this is **not** exactly true and depends on what one means by "succinct." Specifically, "succinct" SNARKs, in the _polylogarithmic proof size_ sense defined by Gentry and Wichs[^GW10], exist from a plethora of assumptions, including discrete log[^BCCplus16] or random oracles[^Mica98]. Furthermore, "succinct" SNARKs, in the sense of $O(1)$ group elements proof size, exist from RSA assumptions too[^LM18]. What pairings do give us, currently, are SNARKs with the smallest, concrete proof sizes (i.e., in # of bytes).
 </Callout>
 
 ## Preliminaries
@@ -561,11 +561,11 @@ I would like to thank Dan Boneh for helping me clarify and contextualize the his
 
 Big thanks to:
 
- - [Lúcás Meier](https://twitter.com/cronokirby), [Pratyush Mishra](https://twitter.com/zkproofs), [Ariel Gabizon](https://twitter.com/rel_zeta_tech) and [Dario Fiore](https://twitter.com/dariofiore0) for their enlightening points on what "succinct" (S) stands for in **S**NARKs[^GW10] and for reminding me that SNARKs with $O(1)$ group elements proof size exist from RSA assumptions[^LM18].
- - [Sergey Vasilyev](https://twitter.com/swasilyev) for pointing out typos in the BLS12-381 elliptic curve definitions.
- - [@BlakeMScurr](https://twitter.com/BlakeMScurr) for pointing out an incorrect reference to Joux's work[^Joux00].
- - [Conrado Guovea](https://twitter.com/conradoplg) for pointing me to Victor Miller's account of how he developed his algorithm for evaluating the Weil pairing (discussed [here](#first-development-millers-algorithm)).
- - [Chris Peikert](https://twitter.com/ChrisPeikert) for pointing out that there are plenty-fast IBE schemes out there that do not rely on pairings[^DLP14e].
+ - [Lúcás Meier](https://x.com/cronokirby), [Pratyush Mishra](https://x.com/zkproofs), [Ariel Gabizon](https://x.com/rel_zeta_tech) and [Dario Fiore](https://x.com/dariofiore0) for their enlightening points on what "succinct" (S) stands for in **S**NARKs[^GW10] and for reminding me that SNARKs with $O(1)$ group elements proof size exist from RSA assumptions[^LM18].
+ - [Sergey Vasilyev](https://x.com/swasilyev) for pointing out typos in the BLS12-381 elliptic curve definitions.
+ - [@BlakeMScurr](https://x.com/BlakeMScurr) for pointing out an incorrect reference to Joux's work[^Joux00].
+ - [Conrado Guovea](https://x.com/conradoplg) for pointing me to Victor Miller's account of how he developed his algorithm for evaluating the Weil pairing (discussed [here](#first-development-millers-algorithm)).
+ - [Chris Peikert](https://x.com/ChrisPeikert) for pointing out that there are plenty-fast IBE schemes out there that do not rely on pairings[^DLP14e].
 
 **PS:** Twitter threads are a pain to search through, so if I missed acknowledging your contribution, please kindly let me know.
 

--- a/apps/nextra/pages/en/network/releases.mdx
+++ b/apps/nextra/pages/en/network/releases.mdx
@@ -41,11 +41,11 @@ Join the Aptos Discord server to interact with us and our community. We also pos
 - [#testnet-release](https://discord.com/channels/945856774056083548/1025614160555413545)
 - [#devnet-release](https://discord.com/channels/945856774056083548/956692649430093904)
 
-### Subscribe via [Aptos Twitter](https://twitter.com/AptosRelease)
+### Subscribe via [Aptos Twitter](https://x.com/AptosRelease)
 
-Follow [@AptosRelease](https://twitter.com/AptosRelease) on Twitter to get the latest updates about our upcoming
+Follow [@AptosRelease](https://x.com/AptosRelease) on Twitter to get the latest updates about our upcoming
 mainnet releases and be notified when it is time to update your node. Every
-couple of days, [@AptosRelease](https://twitter.com/AptosRelease) will tweet a countdown to remind you to update to
+couple of days, [@AptosRelease](https://x.com/AptosRelease) will tweet a countdown to remind you to update to
 the latest version. _Note: We do not post about hotfixes here!_
 
 ## Aptos Release Process


### PR DESCRIPTION
Fix broken link and update installation instructions

- Fixed invalid GitHub actions URL by removing extra slash.
- Improved clarity in the setup steps.
- Minor formatting adjustments for better readability.

fix: update Twitter URL to x.com format
Updated the Twitter URL from https://twitter.com/ to https://x.com/ to reflect the platform's rebranding.