### PR TITLE
Scope legacy plugin wallets to prior adapter versions

### DIFF
--- a/apps/nextra/pages/en/build/sdks/wallet-adapter/browser-extension-wallets.mdx
+++ b/apps/nextra/pages/en/build/sdks/wallet-adapter/browser-extension-wallets.mdx
@@ -65,8 +65,8 @@ In order for dapp users who are not already using your wallet to get the option 
 git checkout -b your-wallet
 ```
 
-### Navigate to [`packages/wallet-adapter-core/src/AIP62StandardWallets`](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/packages/wallet-adapter-core/src/AIP62StandardWallets).
-### Add your wallet’s details to [`registry.ts`](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/packages/wallet-adapter-core/src/AIP62StandardWallets/registry.ts) by following the `AptosStandardSupportedWallet` interface.
+### Navigate to [`packages/wallet-adapter-core/src/AIP62StandardWallets`](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/packages/wallet-adapter-core/src).
+### Add your wallet’s details to [`registry.ts`](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/packages/wallet-adapter-core/src/registry.ts) by following the `AptosStandardSupportedWallet` interface.
 
 ```tsx filename="registry.ts"
 export interface AptosStandardSupportedWallet<Name extends string = string> {

--- a/apps/nextra/pages/en/build/sdks/wallet-adapter/dapp.mdx
+++ b/apps/nextra/pages/en/build/sdks/wallet-adapter/dapp.mdx
@@ -19,6 +19,11 @@ This provides a standard interface for using all Aptos wallets, and allows new w
 ```bash filename="Terminal"
 npm install @aptos-labs/wallet-adapter-react
 ```
+<details>
+
+<summary>
+  <b>For versions prior to v4.0.0</b>
+</summary>
 
 ### (Optional) Install the plugins for any “Legacy Standard Compatible” Wallets you want to support from [this list](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/README.md#supported-wallet-packages).
 
@@ -43,6 +48,8 @@ import { AptosWalletAdapterProvider } from "@aptos-labs/wallet-adapter-react";
 import { OKXWallet } from "@okwallet/aptos-wallet-adapter";
 // ...
 ```
+</details>
+
 
 ### Initialize the `AptosWalletAdapterProvider`.
 

--- a/apps/nextra/pages/en/build/sdks/wallet-adapter/wallets.mdx
+++ b/apps/nextra/pages/en/build/sdks/wallet-adapter/wallets.mdx
@@ -69,7 +69,7 @@ In order for dapp users who are not already using your wallet to get the option 
 git checkout -b your-wallet
 ```
 
-### Navigate to [`packages/wallet-adapter-core/src/AIP62StandardWallets`](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/packages/wallet-adapter-core/src/AIP62StandardWallets).
+### Navigate to [`packages/wallet-adapter-core/src/AIP62StandardWallets`](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/packages/wallet-adapter-core/src).
 
 ### Import your SDK wallet npm package.
 
@@ -77,7 +77,7 @@ git checkout -b your-wallet
 pnpm i @yourpackage
 ```
 
-### Import your wallet in [`sdkWallets.ts`](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/packages/wallet-adapter-core/src/AIP62StandardWallets/sdkWallets.ts).
+### Import your wallet in [`sdkWallets.ts`](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/packages/wallet-adapter-core/src/sdkWallets.ts).
 
 For example with AptosConnect:
 


### PR DESCRIPTION
### Description
Following https://github.com/aptos-labs/aptos-wallet-adapter/pull/464 , the new adapter version now only supports AIP-62 wallets (i.e no legacy plugin wallets)

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
