### PR TITLE
Fetch Ubuntu 22.04 CLI when older OpenSSL detected

### DIFF
--- a/apps/nextra/public/scripts/install_cli.py
+++ b/apps/nextra/public/scripts/install_cli.py
@@ -509,7 +509,7 @@ class Installer:
                 "OpenSSL 1.x.x is deprecated, and future versions of the Aptos CLI may not be published with it",
             )
         )
-        return "Ubuntu-x86_64"
+        return "Ubuntu-22.04-x86_64"
 
     def _write(self, line) -> None:
         sys.stdout.write(line + "\n")


### PR DESCRIPTION
### Description

The `install_cli.py` script currently fetches the 24.04 version in all cases on Linux.

Urgent fix because this is breaking `internal-ops` workflows that download the CLI, as we're still on Ubuntu 22.04 in the CI environment.
