### PR TITLE
add topaz back

### DIFF
--- a/apps/nextra/next.config.mjs
+++ b/apps/nextra/next.config.mjs
@@ -1797,6 +1797,11 @@ export default withBundleAnalyzer(
         permanent: true,
       },
       {
+        source: "/indexer/nft-aggregator/marketplaces/topaz",
+        destination: "/en/build/indexer/nft-aggregator/marketplaces/topaz",
+        permanent: true,
+      },
+      {
         source: "/indexer/nft-aggregator/marketplaces/rarible",
         destination: "/en/build/indexer/nft-aggregator/marketplaces/rarible",
         permanent: true,

--- a/apps/nextra/pages/en/build/indexer/nft-aggregator.mdx
+++ b/apps/nextra/pages/en/build/indexer/nft-aggregator.mdx
@@ -8,10 +8,10 @@ import { IndexerBetaNotice, Card, Cards } from '@components/index';
 import { Callout } from 'nextra/components';
 
 <Callout type="info">
-The NFT Aggregator API is currently in beta. If you’re building an aggregator or need real-time event streaming via gRPC, please reach out to our team for early access and support!
+The NFT Aggregator API is currently in beta. If you're building an aggregator or need real-time event streaming via gRPC, please reach out to our team for early access and support!
 </Callout>
 
-We’re building a **universal NFT aggregator** for the Aptos ecosystem - normalized activity across all major marketplaces, including **Tradeport**, **Wapal**, **bluemove**, **Souffl3**, **Topaz**, and more.
+We're building a **universal NFT aggregator** for the Aptos ecosystem - normalized activity across all major marketplaces, including **Tradeport**, **Wapal**, **Bluemove**, **Rarible**, and more. We also maintain historical data for deprecated marketplaces like **Topaz**.
 
 At its core, the aggregator captures marketplace events in real-time (like listings, token offers, and collection-wide offers) and converts them into clean, structured data. This allows developers to work with a unified data format — no need to handle different marketplace-specific formats manually.
 
@@ -61,7 +61,7 @@ See the full list of marketplaces currently integrated with the NFT Aggregator [
 We handle most integrations directly with your support
 </Callout>
 
-If you’d like your marketplace to be included, please reach out to our team. We support both public integrations and private beta partners.
+If you'd like your marketplace to be included, please reach out to our team. We support both public integrations and private beta partners.
 
 
 ## Next Steps

--- a/apps/nextra/pages/en/build/indexer/nft-aggregator/marketplaces.mdx
+++ b/apps/nextra/pages/en/build/indexer/nft-aggregator/marketplaces.mdx
@@ -34,6 +34,17 @@ For each marketplace, we provide detailed event type mappings, example transacti
   </Card>
 </Cards>
 
+## Deprecated Marketplaces
+
+These marketplaces are no longer operational, but their historical data remains available through our API.
+
+<Cards>
+  <Card href="./marketplaces/topaz.mdx">
+    <Card.Title>Topaz (Deprecated)</Card.Title>
+    <Card.Description>Historical data available for reference</Card.Description>
+  </Card>
+</Cards>
+
 ## Notes
 
 - ✅ All marketplaces share the same core event schema for consistency.

--- a/apps/nextra/pages/en/build/indexer/nft-aggregator/marketplaces/topaz.mdx
+++ b/apps/nextra/pages/en/build/indexer/nft-aggregator/marketplaces/topaz.mdx
@@ -1,0 +1,65 @@
+---
+title: "Topaz (Deprecated)"
+---
+
+import { Callout } from 'nextra/components';
+
+# Topaz (Deprecated)
+
+<Callout type="warning">
+**Marketplace Deprecated**  
+Topaz is no longer operational as a marketplace. However, we continue to include its historical data in our NFT Aggregator for reference.
+</Callout>
+
+## Contract Address
+
+| Contract Version | Account Address |
+|-----------------|----------------|
+| Mainnet | [`0x2c7bccf7b31baf770fdbcc768d9e9cb3d87805e255355df5db32ac9a669010a2`](https://explorer.aptoslabs.com/account/0x2c7bccf7b31baf770fdbcc768d9e9cb3d87805e255355df5db32ac9a669010a2/modules/code/events?network=mainnet) |
+
+*This address is the on-chain account for Topaz's contract deployment.*
+
+---
+
+## Supported Event Types
+
+| Standard Event Type | Raw On-Chain Event Type (entry function) | Example Txn Version |
+|--------------------|------------------------------------------|--------------------|
+| **Offers** | | |
+| `token_offer_created` | `events::BidEvent` | [1645629583](https://explorer.aptoslabs.com/txn/1645629583?network=mainnet) |
+| `token_offer_cancelled` | `events::CancelBidEvent` | [86119627](https://explorer.aptoslabs.com/txn/86119627?network=mainnet) |
+| `token_offer_filled` | `events::SellEvent` | [984827420](https://explorer.aptoslabs.com/txn/984827420?network=mainnet) |
+| **Collection Offers** | | |
+| `collection_offer_created` | `events::CollectionBidEvent` | [85566357](https://explorer.aptoslabs.com/txn/85566357?network=mainnet) |
+| `collection_offer_cancelled` | `events::CancelCollectionBidEvent` | [2787969](https://explorer.aptoslabs.com/txn/2787969?network=mainnet) |
+| `collection_offer_filled` | `events::FillCollectionBidEvent` | [2367804069](https://explorer.aptoslabs.com/txn/2367804069?network=mainnet) |
+| **Listings** | | |
+| `listing_created` | `events::ListEvent` | [1964348978](https://explorer.aptoslabs.com/txn/1964348978?network=mainnet) |
+| `listing_cancelled` | `events::DelistEvent` | [2331658551](https://explorer.aptoslabs.com/txn/2331658551?network=mainnet) |
+| `listing_filled` | `events::BuyEvent` | [2379182335](https://explorer.aptoslabs.com/txn/2379182335?network=mainnet) |
+
+---
+
+## Historical Data Access
+
+While Topaz is no longer operational, all historical marketplace events remain accessible through the NFT Aggregator API. You can filter specifically for Topaz marketplace activity using the `marketplace` field:
+
+```graphql
+query GetTopazHistoricalActivity {
+  nft_marketplace_activities(
+    where: {marketplace: {_eq: "topaz"}}
+  ) {
+    txn_version
+    standard_event_type
+    token_data_id
+    }
+}
+```
+
+---
+
+## Related Docs
+
+- 👉 [NFT Aggregator Table Reference](../nft-aggregator-table.mdx)
+- 👉 [GraphQL API: Real-time Activity](../graphql-api.mdx)
+- 👉 [Integrated Marketplaces Overview](../marketplaces.mdx) 


### PR DESCRIPTION
### Description

- Marked Topaz as a deprecated marketplace
- Created a new "Deprecated Marketplaces" section in the marketplaces overview page
- Clarified that historical data for deprecated marketplaces is still maintained and accessible

### Checklist
- If any existing pages were renamed or removed:
  - [x] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [x] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?