### PR TITLE
Tippi fifestarr patch windows cli

### DIFF
--- a/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
+++ b/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
@@ -17,7 +17,7 @@ For Windows, the easiest way to install the Aptos CLI tool is via Python script.
    ```
 
    <Callout type="warning">
-   If you receive the error `ModuleNotFoundError: No module named packaging` you can install `packaging` by running `pip3 install packaging` then repeat this step.  The above install scripts are for PowerShell specifically (you may have to adapt it based on your terminal of choice).
+   If you receive the error `ModuleNotFoundError: No module named packaging` you can install `packaging` by running `pip3 install packaging` then repeat this step.  The above install scripts are for PowerShell specifically (you may have to adapt it based on your shell of choice).
    </Callout>
 
    You should see instructions in your terminal saying "Execute the following command to update your PATH:".

--- a/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
+++ b/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
@@ -17,7 +17,7 @@ For Windows, the easiest way to install the Aptos CLI tool is via Python script.
    ```
 
    <Callout type="warning">
-   If you receive the error `ModuleNotFoundError: No module named packaging` you can install `packaging` by running `pip3 install packaging` then repeat this step.  Also, the above command is for PowerShell specifically.
+   If you receive the error `ModuleNotFoundError: No module named packaging` you can install `packaging` by running `pip3 install packaging` then repeat this step.  The above install scripts are for PowerShell specifically (you may have to adapt it based on your terminal of choice).
    </Callout>
 
    You should see instructions in your terminal saying "Execute the following command to update your PATH:".

--- a/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
+++ b/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
@@ -6,7 +6,7 @@ For Windows, the easiest way to install the Aptos CLI tool is via Python script.
 
 # Install via Python Script
 <Steps>
-### Ensure you have Python 3.6+ installed by running `python3 --version`
+### Ensure you have Python 3.6+ installed by running `python --version`
 
    If python3 is not installed, you can find installation instructions on [python.org](http://python.org).
 
@@ -17,7 +17,7 @@ For Windows, the easiest way to install the Aptos CLI tool is via Python script.
    ```
 
    <Callout type="warning">
-   If you receive the error `ModuleNotFoundError: No module named packaging` you can install `packaging` by running `pip3 install packaging` then repeat this step.
+   If you receive the error `ModuleNotFoundError: No module named packaging` you can install `packaging` by running `pip3 install packaging` then repeat this step.  Also, the above command is for PowerShell specifically.
    </Callout>
 
    You should see instructions in your terminal saying "Execute the following command to update your PATH:".


### PR DESCRIPTION
### Description
Fix (python3 to python): user testing confirms that windows users will get an error if they run `python3 --version` even if they have a working version of python 3.6+ installed. This error causes beginner devs to suffer 5+ minutes of confusion and perhaps redundant installing.

### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
