### PR TITLE
[Linter] almost_swapped and self_assignment lint rules added to dev docs

### DIFF
--- a/apps/nextra/pages/en/build/smart-contracts/linter.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/linter.mdx
@@ -12,6 +12,11 @@ This tool is currently in beta, so please try it out and submit [bugs and feedba
 
 
 ## Lint Checks
+### `almost_swapped`
+Checks for expression patterns that look like a failed swap attempt and notifies the user. These patterns are likely erroneous code. This currently only detects simple access patterns such as assignments to a variable or a field of a struct. Examples include:
+- `a = b; b = a;` which can be correctly swapped with `(a, b) = (b, a);`
+- `a.x = b.x; b.x = a.x;` which can be correctly swapped with `(a.x, b.x) = (b.x, a.x);`
+
 ### `avoid_copy_on_identity_comparison`
 
 Checks for identity comparisons (`==` or `!=`) between copied values of type `vector` or `struct` (i.e., types for which copy can be expensive). It instead suggests to use reference-based identity comparison instead (i.e., use `&x == &y` instead of `x == y`, when the above mentioned conditions meet).
@@ -88,6 +93,13 @@ Check for boolean expressions that can be simplified when a boolean literal (eit
 
 Does NOT consider side-effects/short-circuiting in the recommended simplifications. Example:
 - `1/0 || true` is logically equivalent to `true`, but applying this simplification affects program semantics.
+
+### `self_assignment`
+
+Checks for patterns where a variable or a field of a struct is assigned to itself and suggests removing the assignment. These assignments do not affect the state of the program. Examples include:
+- `let x = x;`
+- `x = x;`
+- `a.x = a.x;`
 
 ### `simpler_numeric_expression`
 


### PR DESCRIPTION
### Description
Documentation for two new lint rules: `almost_swapped` and `self_assignment`
### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed: N/A
  - [x] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [x] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
