### PR TITLE
[install_cli] fix install_cli.ps1 windows exit

### DIFF
--- a/apps/nextra/public/scripts/install_cli.ps1
+++ b/apps/nextra/public/scripts/install_cli.ps1
@@ -154,7 +154,7 @@ function Main {
         $currentVersion = (& $cliPath --version | Select-String -Pattern '\d+\.\d+\.\d+').Matches.Value
         if ($currentVersion -eq $VERSION) {
             Write-ColorMessage -Color $YELLOW -Message "Aptos CLI version $VERSION is already installed."
-            exit 0
+            return
         }
     }
     
@@ -176,7 +176,7 @@ function Main {
     }
     else {
         Write-ColorMessage -Color $RED -Message "There was a problem with the installation."
-        exit 1
+        return
     }
 }
 


### PR DESCRIPTION
### Description

The current script uses `exit 0` or `exit 1`, which can cause errors in PowerShell when running remote scripts using `iwr https://aptos.dev/scripts/install_cli.ps1 | iex`, or unexpectedly close the terminal during repeated installations — which can be confusing for developers.

**There are two possible solutions:**

1. Use `powershell -NoExit -Command "iwr https://aptos.dev/scripts/install_cli.ps1 | iex"` to prevent the terminal from exiting.

2. Modify the current script to use return instead of exit.

### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
