### PR TITLE
[cli] Add installation shell scripts rather than Python

### DIFF
--- a/apps/nextra/pages/en/build/cli/install-cli/install-cli-linux.mdx
+++ b/apps/nextra/pages/en/build/cli/install-cli/install-cli-linux.mdx
@@ -2,34 +2,30 @@ import { Callout, Steps } from 'nextra/components'
 
 # Install the Aptos CLI on Linux
 
-For Linux, the easiest way to install the Aptos CLI tool is via Python script, although if that does not work, you can also install manually via downloading pre-compiled binaries. The pre-compiled binaries approach is not generally recommended as updating is very manual.
+For Linux, the easiest way to install the Aptos CLI tool is via shell script, although if that does not work, you can also install manually via downloading pre-compiled binaries. The pre-compiled binaries approach is not generally recommended as updating is very manual.
 
-<Callout type="warning">
-Note: If you are using an ARM architecture, you will have to install using the steps here: [Install Specific Aptos CLI Versions (Advanced)](install-cli-specific-version.mdx)
-</Callout>
-
-# Install via Python Script
+# Install via Script
 
 <Steps>
-### Ensure you have Python 3.6+ installed by running `python3 --version`.
-
-   If python3 is not installed, you can find installation instructions on [python.org](http://python.org).
 
 ### In the terminal, use one of the following commands:
 
-  {/* TODO We need to ensure these files are still hosted */}
    ```bash filename="Terminal"
-   curl -fsSL "https://aptos.dev/scripts/install_cli.py" | python3
+   curl -fsSL "https://aptos.dev/scripts/install_cli.sh" | sh
    ```
 
    Or use the equivalent `wget` command:
 
    ```bash filename="Terminal"
-   wget -qO- "https://aptos.dev/scripts/install_cli.py" | python3
+   wget -qO- "https://aptos.dev/scripts/install_cli.sh" | sh
    ```
 
    <Callout type="warning">
-   If you receive the error `Couldn't find distutils or packaging. We cannot check the current version of the CLI. We will install the latest version.` you can fix it by running `pip3 install packaging` then repeating this step.
+     If you are getting `Illegal instruction` errors when running the CLI, it may be due to your CPU not supporting SIMD instructions.
+     Specifically for older non-SIMD processors or Ubuntu x86_64 docker containers on ARM Macs, you may need to run the following command instead to skip SIMD instructions:
+     ```bash filename="Terminal"
+       curl -fsSL "https://aptos.dev/scripts/install_cli.sh" | sh -s -- --generic-linux
+     ```
    </Callout>
 
 ### (Optional) It can be helpful to add the Aptos CLI to a folder in your PATH, or to add it to your PATH directly.
@@ -50,8 +46,8 @@ If you would like to update the Aptos CLI to the latest version, you can run `ap
 ### Go to the [Aptos CLI release page](https://github.com/aptos-labs/aptos-core/releases?q=cli&expanded=true).
 ### Click the "Assets" expandable menu for the latest release to see the pre-compiled binaries.
 ### Download the zip file for Linux.
-   1. It’ll have a name like: `aptos-cli-<version>-Ubuntu-x86_64.zip`.
-   2. Make sure you choose the right zip file for your computer architecture.
+   1. It’ll have a name like: `aptos-cli-<version>-Linux-x86_64.zip` or `aptos-cli-<version>-Linux-aarch64.zip`.
+   2. Make sure you choose the right zip file for your computer architecture (x86_64 for Intel / AMD or aarch64 for ARM).
    3. You will likely have to dismiss warnings that this is a suspicious file when downloading.
 ### Unzip the downloaded file.
 ### Move the extracted Aptos binary file into your preferred folder.

--- a/apps/nextra/pages/en/build/cli/install-cli/install-cli-mac.mdx
+++ b/apps/nextra/pages/en/build/cli/install-cli/install-cli-mac.mdx
@@ -23,7 +23,7 @@ aptos help
 </Steps>
 
 <Callout type="warning">
-If `brew` does not work for you, you can try the steps here: [Install Specific Aptos CLI Versions (Advanced)](install-cli-specific-version.mdx)
+If `brew` does not work for you, you can try the steps here: [Install via Script](#install-via-script) or [Install via Pre-Compiled Binaries](#install-via-pre-compiled-binaries-backup-method).)
 </Callout>
 
 # Upgrading the CLI
@@ -34,3 +34,55 @@ Upgrading the CLI with brew just takes 2 commands:
 brew update
 brew upgrade aptos
 ```
+
+# Install via Script
+
+<Steps>
+  ### In the terminal, use one of the following commands:
+
+  ```bash filename="Terminal"
+  curl -fsSL "https://aptos.dev/scripts/install_cli.sh" | sh
+  ```
+
+  Or use the equivalent `wget` command:
+
+  ```bash filename="Terminal"
+  wget -qO- "https://aptos.dev/scripts/install_cli.sh" | sh
+  ```
+
+  ### (Optional) It can be helpful to add the Aptos CLI to a folder in your PATH, or to add it to your PATH directly.
+  - The steps to add a folder to your PATH are shell dependent.
+  - You can run `echo $SHELL` to print the default shell for your machine, then google specific steps to add a folder to your PATH for that shell.
+  ### Verify the script is installed by opening a new terminal and running `aptos help`
+  - You should see a list of commands you can run using the CLI.
+  - In the future, this is a helpful resource to learn exactly how each command works.
+</Steps>
+
+<Callout type="info" emoji="ℹ️">
+  If you would like to update the Aptos CLI to the latest version, you can run `aptos update`.
+</Callout>
+
+# Install via Pre-Compiled Binaries (Backup Method)
+
+<Steps>
+  ### Go to the [Aptos CLI release page](https://github.com/aptos-labs/aptos-core/releases?q=cli&expanded=true).
+  ### Click the "Assets" expandable menu for the latest release to see the pre-compiled binaries.
+  ### Download the zip file for macOS.
+  1. It’ll have a name like: `aptos-cli-<version>-macOS-x86_64.zip` or `aptos-cli-<version>-macOS-arm64.zip`.
+  2. Make sure you choose the right zip file for your computer architecture (x86_64 for Intel / AMD or arm64 for ARM).
+  3. You will likely have to dismiss warnings that this is a suspicious file when downloading.
+  ### Unzip the downloaded file.
+  ### Move the extracted Aptos binary file into your preferred folder.
+  ### Open a terminal and navigate to your preferred folder.
+  ### Make `~/aptos` an executable by running `chmod +x ~/aptos`.
+  ### Verify that this installed version works by running `~/aptos help`.
+  You should see instructions for how to use all CLI commands. These can be helpful in the future when you are trying to understand how to use specific commands.
+  ### (Optional) It can be helpful to add the Aptos CLI to a folder in your PATH, or to add it to your PATH directly.
+  - The steps to add a folder to your PATH are shell dependent.
+  - You can run `echo $SHELL` to print the default shell for your machine, then google specific steps to add a folder to your PATH for that shell.
+
+</Steps>
+
+<Callout type="info" emoji="ℹ️">
+  When using the pre-compiled binaries method, you can update the Aptos CLI by deleting your existing installation, then following the installation steps again.
+</Callout>

--- a/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
+++ b/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
@@ -2,23 +2,16 @@ import { Callout, Steps } from 'nextra/components'
 
 # Install the Aptos CLI on Windows
 
-For Windows, the easiest way to install the Aptos CLI tool is via Python script. If that does not work, you can also install manually via pre-compiled binaries. The pre-compiled binaries approach is not generally recommended as updating is very manual.
+For Windows, the easiest way to install the Aptos CLI tool is via PowerShell script. If that does not work, you can also install manually via pre-compiled binaries. The pre-compiled binaries approach is not generally recommended as updating is very manual.
 
-# Install via Python Script
+# Install via PowerShell Script
 <Steps>
-### Ensure you have Python 3.6+ installed by running `python --version`
-
-   If python3 is not installed, you can find installation instructions on [python.org](http://python.org).
-
 ### In PowerShell, run the install script:
 
    ```powershell filename="Terminal"
-   Invoke-WebRequest -Uri "https://aptos.dev/scripts/install_cli.py" -OutFile "$env:TEMP\install_cli.py"; python "$env:TEMP\install_cli.py"
+     Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+     Invoke-RestMethod -Uri https://aptos.dev/scripts/install_cli.ps1 | Invoke-Expression
    ```
-
-   <Callout type="warning">
-   If you receive the error `ModuleNotFoundError: No module named packaging` you can install `packaging` by running `pip3 install packaging` then repeat this step.  The above install scripts are for PowerShell specifically (you may have to adapt it based on your shell of choice).
-   </Callout>
 
    You should see instructions in your terminal saying "Execute the following command to update your PATH:".
 ### Copy and run the command to update your PATH from the terminal.


### PR DESCRIPTION
### Description
Python requires you to know how to first install Python, which then requires more work.  This lets you run everything with just the native shell tools available on every machine.

### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?
