### PR TITLE
[cli] Update the Windows installation guide, simplify the PowerShell script…

### DIFF
--- a/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
+++ b/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
@@ -9,14 +9,8 @@ For Windows, the easiest way to install the Aptos CLI tool is via PowerShell scr
 ### In PowerShell, run the install script:
 
    ```powershell filename="Terminal"
-     Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
-     Invoke-RestMethod -Uri https://aptos.dev/scripts/install_cli.ps1 | Invoke-Expression
+   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser; iwr https://aptos.dev/scripts/install_cli.ps1 | iex
    ```
-
-   You should see instructions in your terminal saying "Execute the following command to update your PATH:".
-### Copy and run the command to update your PATH from the terminal.
-
-   It should look something like `setx PATH "%PATH%;C:\Users\<your_account_name>\.aptoscli\bin"`.
 
 ### Verify the script is installed by opening a new terminal and running `aptos help`.
    - You should see a list of commands you can run using the CLI.
@@ -26,6 +20,19 @@ For Windows, the easiest way to install the Aptos CLI tool is via PowerShell scr
 <Callout type="info" emoji="ℹ️">
 If you would like to update the Aptos CLI to the latest version via script, you can run `aptos update`.
 </Callout>
+
+# Install via Package Manager (Optional)
+
+### If you have [Scoop](https://scoop.sh/) installed, you can run the following command to install the Aptos CLI:
+
+   ```powershell filename="Terminal"
+   scoop install https://aptos.dev/scoop/aptos.json
+   ```
+### If you have [Chocolatey](https://chocolatey.org/) installed, you can run the following command to install the Aptos CLI:
+
+   ```powershell filename="Terminal"
+   choco install aptos
+   ```
 
 # Install via Pre-Compiled Binaries (Backup Method)
 

--- a/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
+++ b/apps/nextra/pages/en/build/cli/install-cli/install-cli-windows.mdx
@@ -23,6 +23,10 @@ If you would like to update the Aptos CLI to the latest version via script, you 
 
 # Install via Package Manager (Optional)
 
+<Callout type="info">
+When installing Aptos via a package manager, please update it through the same package manager in the future.
+</Callout>
+
 ### If you have [Scoop](https://scoop.sh/) installed, you can run the following command to install the Aptos CLI:
 
    ```powershell filename="Terminal"

--- a/apps/nextra/public/scoop/aptos.json
+++ b/apps/nextra/public/scoop/aptos.json
@@ -1,0 +1,21 @@
+{
+    "version":  "7.3.0",
+    "license":  "Apache-2.0",
+    "description": "Aptos is a layer 1 blockchain built to support the widespread use of blockchain through better technology and user experience. (CLI)",
+    "homepage":  "https://github.com/aptos-labs/aptos-core/",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/aptos-labs/aptos-core/releases/download/aptos-cli-v7.3.0/aptos-cli-7.3.0-Windows-x86_64.zip",
+            "hash": "d20395e6b4cdb07d508f7ff66db0ce0fa19725ce72db4068b4a95f1785535843"
+        }
+    },
+    "bin":  "aptos.exe",
+    "checkver": {
+        "url": "https://api.github.com/repos/aptos-labs/aptos-core/releases/tags/aptos-cli-v7.3.0",
+        "jsonpath": "$.tag_name",
+        "regex": "aptos-cli-v([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/aptos-labs/aptos-core/releases/download/aptos-cli-v$version/aptos-cli-$version-Windows-x86_64.zip"
+    }
+}

--- a/apps/nextra/public/scoop/aptos.json
+++ b/apps/nextra/public/scoop/aptos.json
@@ -1,21 +1,21 @@
 {
-    "version":  "7.3.0",
-    "license":  "Apache-2.0",
-    "description": "Aptos is a layer 1 blockchain built to support the widespread use of blockchain through better technology and user experience. (CLI)",
-    "homepage":  "https://github.com/aptos-labs/aptos-core/",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/aptos-labs/aptos-core/releases/download/aptos-cli-v7.3.0/aptos-cli-7.3.0-Windows-x86_64.zip",
-            "hash": "d20395e6b4cdb07d508f7ff66db0ce0fa19725ce72db4068b4a95f1785535843"
-        }
-    },
-    "bin":  "aptos.exe",
-    "checkver": {
-        "url": "https://api.github.com/repos/aptos-labs/aptos-core/releases/tags/aptos-cli-v7.3.0",
-        "jsonpath": "$.tag_name",
-        "regex": "aptos-cli-v([\\d.]+)"
-    },
-    "autoupdate": {
-        "url": "https://github.com/aptos-labs/aptos-core/releases/download/aptos-cli-v$version/aptos-cli-$version-Windows-x86_64.zip"
+  "version": "7.3.0",
+  "license": "Apache-2.0",
+  "description": "Aptos is a layer 1 blockchain built to support the widespread use of blockchain through better technology and user experience. (CLI)",
+  "homepage": "https://github.com/aptos-labs/aptos-core/",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/aptos-labs/aptos-core/releases/download/aptos-cli-v7.3.0/aptos-cli-7.3.0-Windows-x86_64.zip",
+      "hash": "d20395e6b4cdb07d508f7ff66db0ce0fa19725ce72db4068b4a95f1785535843"
     }
+  },
+  "bin": "aptos.exe",
+  "checkver": {
+    "url": "https://api.github.com/repos/aptos-labs/aptos-core/releases/tags/aptos-cli-v7.3.0",
+    "jsonpath": "$.tag_name",
+    "regex": "aptos-cli-v([\\d.]+)"
+  },
+  "autoupdate": {
+    "url": "https://github.com/aptos-labs/aptos-core/releases/download/aptos-cli-v$version/aptos-cli-$version-Windows-x86_64.zip"
+  }
 }


### PR DESCRIPTION
### Description

Update the Windows installation guide, simplify the PowerShell script, and add Scoop and Chocolatey installation options.

```
choco install aptos

scoop install https://aptos.dev/scoop/aptos.json
```

Install Aptos using a shorter PowerShell command.

```
Set-ExecutionPolicy RemoteSigned -Scope CurrentUser; iwr https://aptos.dev/scripts/install_cli.ps1 | iex
```
### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
