### PR TITLE
fix marketplace link

### DIFF
--- a/apps/nextra/pages/en/build/indexer/nft-aggregator/marketplaces.mdx
+++ b/apps/nextra/pages/en/build/indexer/nft-aggregator/marketplaces.mdx
@@ -13,22 +13,22 @@ For each marketplace, we provide detailed event type mappings, example transacti
 </Callout>
 
 <Cards>
-  <Card href="./marketplaces/tradeport.mdx">
+  <Card href="./marketplaces/tradeport">
     <Card.Title>Tradeport</Card.Title>
     <Card.Description>View supported events and example transactions for Tradeport</Card.Description>
   </Card>
   
-  <Card href="./marketplaces/bluemove.mdx">
+  <Card href="./marketplaces/bluemove">
     <Card.Title>Bluemove</Card.Title>
     <Card.Description>View supported events and example transactions for Bluemove</Card.Description>
   </Card>
   
-  <Card href="./marketplaces/wapal.mdx">
+  <Card href="./marketplaces/wapal">
     <Card.Title>Wapal</Card.Title>
     <Card.Description>View supported events and example transactions for Wapal</Card.Description>
   </Card>
   
-  <Card href="./marketplaces/rarible.mdx">
+  <Card href="./marketplaces/rarible">
     <Card.Title>Rarible</Card.Title>
     <Card.Description>View supported events and example transactions for Rarible</Card.Description>
   </Card>
@@ -39,7 +39,7 @@ For each marketplace, we provide detailed event type mappings, example transacti
 These marketplaces are no longer operational, but their historical data remains available through our API.
 
 <Cards>
-  <Card href="./marketplaces/topaz.mdx">
+  <Card href="./marketplaces/topaz">
     <Card.Title>Topaz (Deprecated)</Card.Title>
     <Card.Description>Historical data available for reference</Card.Description>
   </Card>


### PR DESCRIPTION
### Description
Fixed marketplace link where it used to link to mdx 
### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you ran `pnpm lint`?

tested locally