### PR TITLE
[links] Ignore Google cloud link, works, but not through CI

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -48,6 +48,7 @@ jobs:
             --exclude '.*imageUrl.*'
             --exclude '^(file:|[./]).*\/network\/faucet.mdx$'
             --exclude '^https://x\.com/.*'
+            --exclude '^https://console.cloud.google.com/marketplace/product/bigquery-public-data/crypto-aptos-mainnet-us$'
             --accept '403,401,429'
             --retry-wait-time 1
             --max-retries 2


### PR DESCRIPTION
### Description

### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
