### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/apps/nextra/pages/en/build/guides/key-rotation.mdx
+++ b/apps/nextra/pages/en/build/guides/key-rotation.mdx
@@ -95,7 +95,7 @@ CLI tutorial).
 Unlike [`account::rotate_authentication_key`], the
 [`account::rotate_authentication_key_call`] does _not_ require a signed
 [`account::RotationProofChallenge`]. This means that the operation is not proven
-in the sense the the private key from _after_ the operation has approved the
+in the sense the private key from _after_ the operation has approved the
 key rotation. Hence the [`account::OriginatingAddress`] table is _not_ updated
 for unproven key rotations, and there is thus no restriction on the number of
 accounts that can be authenticated with a given private key. Note that the

--- a/apps/nextra/pages/en/build/indexer/indexer-sdk/advanced-tutorials/processor-test.mdx
+++ b/apps/nextra/pages/en/build/indexer/indexer-sdk/advanced-tutorials/processor-test.mdx
@@ -58,7 +58,7 @@ Before setting up the test environment, it’s important to understand the confi
 **What Are These Configurations?**
 
 `generate_file_flag`
-- If `generate_file_flag` is true, the test will overwrite any saved database outputs from previous test runs. If `generate_file_flag` is false, the test will only compare the the actual database output with the expected database output and log differences.
+- If `generate_file_flag` is true, the test will overwrite any saved database outputs from previous test runs. If `generate_file_flag` is false, the test will only compare the actual database output with the expected database output and log differences.
 
 
 `custom_output_path`


### PR DESCRIPTION
### Description

remove redundant word in comment

### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
