### PR TITLE
[gha] allow external contributors build/lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,27 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
+    branches:
+      - 06-18-_gha_allow_external_contributors_build_lint # canary for the PR that introduces pull_request_target
 
 permissions:
   contents: read
   id-token: write #required for GCP Workload Identity federation which we use to login into Google Artifact Registry
 
 jobs:
+  permission-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check repository permission for user which triggered workflow
+        uses: sushichop/action-repository-permission@13d208f5ae7a6a3fc0e5a7c2502c214983f0241c
+        with:
+          required-permission: write
+          comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
+
   lint:
     runs-on: ubuntu-latest
+    needs: permission-check # This is required to ensure we have permission to build against the GCP Artifact Registry
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR introduces `pull_request_target` for the main CI build/lint job. It requires  permissions since there are some internal packages that are used in part of the build. The `permission-check` job ensures the permissions are locked down, and Semgrep enforces that job's existence. 

This PR is tested by #992 , which should be safe to land alongside it as long as Semgrep passes on it