### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/apps/nextra/pages/en/build/cli/trying-things-on-chain/ledger.mdx
+++ b/apps/nextra/pages/en/build/cli/trying-things-on-chain/ledger.mdx
@@ -514,7 +514,7 @@ aptos config rename-profile \
 ### Rotate back to Ledger
 
 Once you've signed the large package publication transaction with the hot key,
-you can then rotate the authentication key back to to the corresponding to the
+you can then rotate the authentication key back to the corresponding to the
 private key on the Ledger at index 1000:
 
 ```sh filename="Terminal"

--- a/apps/nextra/pages/en/build/sdks/dotnet-sdk/accounts/ed25519.mdx
+++ b/apps/nextra/pages/en/build/sdks/dotnet-sdk/accounts/ed25519.mdx
@@ -23,7 +23,7 @@ Ed25519Accounts are created to sign transactions and interact with the blockchai
 
 ### Using a Private Key
 
-To generate an account from a private key, you will need to create the `Ed25519PrivateKey` object and pass into into the
+To generate an account from a private key, you will need to create the `Ed25519PrivateKey` object and pass into the
 `Ed25519Account` constructor. The private key can be given a `string` or `byte[]` representation.
 
 ```csharp

--- a/apps/nextra/pages/en/build/smart-contracts/book/variables.mdx
+++ b/apps/nextra/pages/en/build/smart-contracts/book/variables.mdx
@@ -635,7 +635,7 @@ Currently these are only applicable to numeric values.
 | `*=`   | Performs multiplication and updates the left-hand value      |
 | `%=`   | Performs modular division and updates the left-hand value    |
 | `/=`   | Performs truncating division and updates the left-hand value |
-| `&=`   | Performs bitwise and and updates the left-hand value         |
+| `&=`   | Performs bitwise and updates the left-hand value         |
 | `\|=`  | Performs bitwise or and updates the left-hand value          |
 | `^=`   | Performs bitwise xor and updates the left-hand value         |
 | `<<=`  | Performs shift left and updates the left-hand value          |


### PR DESCRIPTION
### Description

remove redundant words in comment


### Checklist
<!-- Read the Nextra Contributor's Guide here: https://aptos.dev/en/developer-platforms/contribute -->

- If any existing pages were renamed or removed:
  - [ ] Were redirects added to [next.config.mjs](../apps/nextra/next.config.mjs)?
  - [ ] Did you update any relative links that pointed to the renamed / removed pages?
- Do all Lints pass?
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you ran `pnpm lint`?
